### PR TITLE
Minor changes to support required fields and fix to have Iterable parameters 

### DIFF
--- a/lib/src/annotations/marshalers/iterable_marshaler.dart
+++ b/lib/src/annotations/marshalers/iterable_marshaler.dart
@@ -22,8 +22,8 @@ class IterableMarshaler extends Marshaler {
     final toList = type.isDartCoreList ? '.toList()' : '';
     final item = '(v) => ${convert('v')}';
     return (type.nullabilitySuffix == NullabilitySuffix.none)
-        ? (list) => '$list.map($item})$toList'
-        : (list) => '$list?.map($item})$toList';
+        ? (list) => '$list.map($item)$toList'
+        : (list) => '$list?.map($item)$toList';
   }
 
   @override

--- a/lib/src/annotations/squadron_parameter.dart
+++ b/lib/src/annotations/squadron_parameter.dart
@@ -42,8 +42,7 @@ class SquadronParameter {
         field,
         param.isNamed,
         param.isOptionalPositional,
-        (param.isOptionalNamed || param.isOptionalPositional) &&
-            param.isRequired,
+        param.isRequiredNamed,
         isToken,
         param.defaultValueCode,
         marshaler,


### PR DESCRIPTION
I tried to use this builder ob my project configured on dart 3.0.0/flutter 3.10 and faced with some problems
- it's was not able to generated isolate proxy methods (@SquadronMethod annotated) with named and required not null parameters
- and it's was some mistakes in marshalling with Iterable or List parameters


Please review the fix
Thanks