### PR TITLE
Allow usage of analyzer v6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   squadron: ">=4.3.5 <6.0.0"
   build: ^2.3.1
   source_gen: ^1.3.1
-  analyzer: ^5.11.1
+  analyzer: ">=5.11.1 <7.0.0"
   meta: ^1.8.0
 
 dev_dependencies:


### PR DESCRIPTION
Since more and more packages are gonna bump their analyzer to v6, I thought it would be wise to gracefully update the version using

```yaml
analyzer: ">=5.11.1 <7.0.0"
```

This won't break older apps and will allow newer ones to use the package without any issues.