### PR TITLE
Feat/source gen 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.5-mki
+
+- Update for source_gen 3.0.0
+
 ## 7.1.4
 
 - Rename `WorkerAssets.override` to `override_` to avoid confusion with `dart:core`'s top-level `override` constant -- fixes https://github.com/d-markey/squadron_builder/issues/34.

--- a/example/fibonacci/generated/fib_service.activator.g.dart
+++ b/example/fibonacci/generated/fib_service.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'fib_service.stub.g.dart'

--- a/example/fibonacci/generated/fib_service.stub.g.dart
+++ b/example/fibonacci/generated/fib_service.stub.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/fibonacci/generated/fib_service.vm.g.dart
+++ b/example/fibonacci/generated/fib_service.vm.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/fibonacci/generated/fib_service.web.g.dart
+++ b/example/fibonacci/generated/fib_service.web.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/fibonacci/generated/fib_service.worker.g.dart
+++ b/example/fibonacci/generated/fib_service.worker.g.dart
@@ -74,33 +74,151 @@ WorkerService $FibServiceInitializer(WorkerRequest $req) =>
     _$FibService$WorkerService();
 
 /// Worker for FibService
-base class FibServiceWorker extends Worker
+base class _$FibServiceWorker extends Worker
     with _$FibService$Invoker, _$FibService$Facade
     implements FibService {
-  FibServiceWorker(
+  _$FibServiceWorker(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($FibServiceActivator(Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  FibServiceWorker.vm(
+  _$FibServiceWorker.vm(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($FibServiceActivator(SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  FibServiceWorker.js(
+  _$FibServiceWorker.js(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($FibServiceActivator(SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
   @dc.override
   dc.List? getStartArgs() => null;
+
+  final _$detachToken = dc.Object();
+}
+
+/// Finalizable worker wrapper for FibService
+base class FibServiceWorker with Releasable implements _$FibServiceWorker {
+  FibServiceWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  FibServiceWorker(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$FibServiceWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  FibServiceWorker.vm(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$FibServiceWorker.vm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  FibServiceWorker.js(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$FibServiceWorker.js(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$FibServiceWorker _$worker;
+
+  static final dc.Finalizer<_$FibServiceWorker> _finalizer =
+      dc.Finalizer<_$FibServiceWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @dc.override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @dc.override
+  dc.List? getStartArgs() => null;
+
+  @dc.override
+  Future<dc.int> fibonacci(dc.int i) => _$worker.fibonacci(i);
+
+  @dc.override
+  dc.int get x => _$worker.x;
+
+  @dc.override
+  ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @dc.override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @dc.override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @dc.override
+  dc.bool get isConnected => _$worker.isConnected;
+
+  @dc.override
+  dc.bool get isStopped => _$worker.isStopped;
+
+  @dc.override
+  WorkerStat get stats => _$worker.stats;
+
+  @dc.override
+  WorkerStat getStats() => _$worker.getStats();
+
+  @dc.override
+  Future<Channel> start() => _$worker.start();
+
+  @dc.override
+  void stop() => _$worker.stop();
+
+  @dc.override
+  void terminate([TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @dc.override
+  Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @dc.override
+  Future<dc.dynamic> send(dc.int command,
+          {dc.List args = const [],
+          CancelationToken? token,
+          dc.bool inspectRequest = false,
+          dc.bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @dc.override
+  Stream<dc.dynamic> stream(dc.int command,
+          {dc.List args = const [],
+          CancelationToken? token,
+          dc.bool inspectRequest = false,
+          dc.bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @dc.override
+  dc.Object get _$detachToken => _$worker._$detachToken;
+
+  @dc.override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 /// Worker pool for FibService
-base class FibServiceWorkerPool extends WorkerPool<FibServiceWorker>
+base class _$FibServiceWorkerPool extends WorkerPool<FibServiceWorker>
     with _$FibService$Facade
     implements FibService {
-  FibServiceWorkerPool(
+  _$FibServiceWorkerPool(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -110,7 +228,7 @@ base class FibServiceWorkerPool extends WorkerPool<FibServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  FibServiceWorkerPool.vm(
+  _$FibServiceWorkerPool.vm(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -120,7 +238,7 @@ base class FibServiceWorkerPool extends WorkerPool<FibServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  FibServiceWorkerPool.js(
+  _$FibServiceWorkerPool.js(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -132,6 +250,156 @@ base class FibServiceWorkerPool extends WorkerPool<FibServiceWorker>
 
   @dc.override
   Future<dc.int> fibonacci(dc.int i) => execute((w) => w.fibonacci(i));
+
+  final _$detachToken = dc.Object();
+}
+
+/// Finalizable worker pool wrapper for FibService
+base class FibServiceWorkerPool
+    with Releasable
+    implements _$FibServiceWorkerPool {
+  FibServiceWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  FibServiceWorkerPool(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$FibServiceWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  FibServiceWorkerPool.vm(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$FibServiceWorkerPool.vm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  FibServiceWorkerPool.js(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$FibServiceWorkerPool.js(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$FibServiceWorkerPool _$pool;
+
+  static final dc.Finalizer<_$FibServiceWorkerPool> _finalizer =
+      dc.Finalizer<_$FibServiceWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @dc.override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @dc.override
+  Future<dc.int> fibonacci(dc.int i) => _$pool.fibonacci(i);
+
+  @dc.override
+  dc.int get x => _$pool.x;
+
+  @dc.override
+  ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @dc.override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @dc.override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @dc.override
+  ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @dc.override
+  dc.Iterable<WorkerStat> get fullStats => _$pool.fullStats;
+
+  @dc.override
+  dc.int get pendingWorkload => _$pool.pendingWorkload;
+
+  @dc.override
+  dc.int get maxSize => _$pool.maxSize;
+
+  @dc.override
+  dc.int get size => _$pool.size;
+
+  @dc.override
+  dc.Iterable<WorkerStat> get stats => _$pool.stats;
+
+  @dc.override
+  dc.bool get stopped => _$pool.stopped;
+
+  @dc.override
+  void cancelAll([dc.String? message]) => _$pool.cancelAll(message);
+
+  @dc.override
+  void cancel(Task task, [dc.String? message]) => _$pool.cancel(task, message);
+
+  @dc.override
+  FutureOr<void> start() => _$pool.start();
+
+  @dc.override
+  dc.int stop([dc.bool Function(FibServiceWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @dc.override
+  void terminate([TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @dc.override
+  dc.Object registerWorkerPoolListener(
+          void Function(WorkerStat, dc.bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @dc.override
+  void unregisterWorkerPoolListener(
+          {void Function(WorkerStat, dc.bool)? listener, dc.Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @dc.override
+  Future<T> execute<T>(Future<T> Function(FibServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @dc.override
+  Stream<T> stream<T>(Stream<T> Function(FibServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @dc.override
+  StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(FibServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @dc.override
+  ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(FibServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @dc.override
+  dc.Object get _$detachToken => _$pool._$detachToken;
+
+  @dc.override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 final class _$Deser extends MarshalingContext {

--- a/example/fibonacci/generated/fib_service.worker.g.dart
+++ b/example/fibonacci/generated/fib_service.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../fib_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/hello_world/generated/hello_world.activator.g.dart
+++ b/example/hello_world/generated/hello_world.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'hello_world.stub.g.dart'

--- a/example/hello_world/generated/hello_world.stub.g.dart
+++ b/example/hello_world/generated/hello_world.stub.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/hello_world/generated/hello_world.vm.g.dart
+++ b/example/hello_world/generated/hello_world.vm.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/hello_world/generated/hello_world.web.g.dart
+++ b/example/hello_world/generated/hello_world.web.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/hello_world/generated/hello_world.worker.g.dart
+++ b/example/hello_world/generated/hello_world.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../hello_world.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/hello_world/generated/hello_world.worker.g.dart
+++ b/example/hello_world/generated/hello_world.worker.g.dart
@@ -55,38 +55,158 @@ WorkerService $HelloWorldInitializer(WorkerRequest $req) =>
     _$HelloWorld$WorkerService();
 
 /// Worker for HelloWorld
-base class HelloWorldWorker extends Worker
+base class _$HelloWorldWorker extends Worker
     with _$HelloWorld$Invoker, _$HelloWorld$Facade
     implements HelloWorld {
-  HelloWorldWorker(
+  _$HelloWorldWorker(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($HelloWorldActivator(Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  HelloWorldWorker.vm(
+  _$HelloWorldWorker.vm(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($HelloWorldActivator(SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  HelloWorldWorker.js(
+  _$HelloWorldWorker.js(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($HelloWorldActivator(SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  HelloWorldWorker.wasm(
+  _$HelloWorldWorker.wasm(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($HelloWorldActivator(SquadronPlatformType.wasm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for HelloWorld
+base class HelloWorldWorker with Releasable implements _$HelloWorldWorker {
+  HelloWorldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  HelloWorldWorker(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$HelloWorldWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  HelloWorldWorker.vm(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$HelloWorldWorker.vm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  HelloWorldWorker.js(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$HelloWorldWorker.js(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  HelloWorldWorker.wasm(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$HelloWorldWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$HelloWorldWorker _$worker;
+
+  static final Finalizer<_$HelloWorldWorker> _finalizer =
+      Finalizer<_$HelloWorldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<String> sayHello([String? name]) => _$worker.sayHello(name);
+
+  @override
+  ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  WorkerStat get stats => _$worker.stats;
+
+  @override
+  WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 /// Worker pool for HelloWorld
-base class HelloWorldWorkerPool extends WorkerPool<HelloWorldWorker>
+base class _$HelloWorldWorkerPool extends WorkerPool<HelloWorldWorker>
     with _$HelloWorld$Facade
     implements HelloWorld {
-  HelloWorldWorkerPool(
+  _$HelloWorldWorkerPool(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -96,7 +216,7 @@ base class HelloWorldWorkerPool extends WorkerPool<HelloWorldWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  HelloWorldWorkerPool.vm(
+  _$HelloWorldWorkerPool.vm(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -106,7 +226,7 @@ base class HelloWorldWorkerPool extends WorkerPool<HelloWorldWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  HelloWorldWorkerPool.js(
+  _$HelloWorldWorkerPool.js(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -116,7 +236,7 @@ base class HelloWorldWorkerPool extends WorkerPool<HelloWorldWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  HelloWorldWorkerPool.wasm(
+  _$HelloWorldWorkerPool.wasm(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -128,6 +248,161 @@ base class HelloWorldWorkerPool extends WorkerPool<HelloWorldWorker>
 
   @override
   Future<String> sayHello([String? name]) => execute((w) => w.sayHello(name));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for HelloWorld
+base class HelloWorldWorkerPool
+    with Releasable
+    implements _$HelloWorldWorkerPool {
+  HelloWorldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  HelloWorldWorkerPool(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$HelloWorldWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  HelloWorldWorkerPool.vm(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$HelloWorldWorkerPool.vm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  HelloWorldWorkerPool.js(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$HelloWorldWorkerPool.js(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  HelloWorldWorkerPool.wasm(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$HelloWorldWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$HelloWorldWorkerPool _$pool;
+
+  static final Finalizer<_$HelloWorldWorkerPool> _finalizer =
+      Finalizer<_$HelloWorldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<String> sayHello([String? name]) => _$pool.sayHello(name);
+
+  @override
+  ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(HelloWorldWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(void Function(WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(HelloWorldWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(HelloWorldWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(HelloWorldWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(HelloWorldWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 final class _$Deser extends MarshalingContext {

--- a/example/local/generated/some_service.activator.g.dart
+++ b/example/local/generated/some_service.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'some_service.vm.g.dart';

--- a/example/local/generated/some_service.vm.g.dart
+++ b/example/local/generated/some_service.vm.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/local/generated/some_service.worker.g.dart
+++ b/example/local/generated/some_service.worker.g.dart
@@ -63,10 +63,10 @@ WorkerService $SomeServiceInitializer(WorkerRequest $req) {
 }
 
 /// Worker for SomeService
-base class SomeServiceWorker extends Worker
+base class _$SomeServiceWorker extends Worker
     with _$SomeService$Invoker, _$SomeService$Facade
     implements SomeService {
-  SomeServiceWorker(
+  _$SomeServiceWorker(
       {this.threadIdService,
       PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager})
@@ -74,7 +74,7 @@ base class SomeServiceWorker extends Worker
         super($SomeServiceActivator(Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  SomeServiceWorker.vm(
+  _$SomeServiceWorker.vm(
       {this.threadIdService,
       PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager})
@@ -105,13 +105,143 @@ base class SomeServiceWorker extends Worker
 
   @override
   final id.ThreadIdentityService? threadIdService;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for SomeService
+base class SomeServiceWorker with Releasable implements _$SomeServiceWorker {
+  SomeServiceWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  SomeServiceWorker(
+      {id.ThreadIdentityService? threadIdService,
+      PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager})
+      : this._(_$SomeServiceWorker(
+            threadIdService: threadIdService,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  SomeServiceWorker.vm(
+      {id.ThreadIdentityService? threadIdService,
+      PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager})
+      : this._(_$SomeServiceWorker.vm(
+            threadIdService: threadIdService,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  @override
+  id.ThreadIdentityService? get threadIdService => _$worker.threadIdService;
+
+  final _$SomeServiceWorker _$worker;
+
+  static final Finalizer<_$SomeServiceWorker> _finalizer =
+      Finalizer<_$SomeServiceWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<LocalWorker?> get _$localWorkers => const [];
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<String> getThreadId() => _$worker.getThreadId();
+
+  @override
+  Future<String> getThreadIdFromLocal() => _$worker.getThreadIdFromLocal();
+
+  @override
+  ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  WorkerStat get stats => _$worker.stats;
+
+  @override
+  WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 /// Worker pool for SomeService
-base class SomeServiceWorkerPool extends WorkerPool<SomeServiceWorker>
+base class _$SomeServiceWorkerPool extends WorkerPool<SomeServiceWorker>
     with _$SomeService$Facade
     implements SomeService {
-  SomeServiceWorkerPool(
+  _$SomeServiceWorkerPool(
       {this.threadIdService,
       PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
@@ -124,7 +254,7 @@ base class SomeServiceWorkerPool extends WorkerPool<SomeServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  SomeServiceWorkerPool.vm(
+  _$SomeServiceWorkerPool.vm(
       {this.threadIdService,
       PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
@@ -146,6 +276,153 @@ base class SomeServiceWorkerPool extends WorkerPool<SomeServiceWorker>
   @override
   Future<String> getThreadIdFromLocal() =>
       execute((w) => w.getThreadIdFromLocal());
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for SomeService
+base class SomeServiceWorkerPool
+    with Releasable
+    implements _$SomeServiceWorkerPool {
+  SomeServiceWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  SomeServiceWorkerPool(
+      {id.ThreadIdentityService? threadIdService,
+      PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$SomeServiceWorkerPool(
+            threadIdService: threadIdService,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  SomeServiceWorkerPool.vm(
+      {id.ThreadIdentityService? threadIdService,
+      PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$SomeServiceWorkerPool.vm(
+            threadIdService: threadIdService,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  @override
+  id.ThreadIdentityService? get threadIdService => _$pool.threadIdService;
+
+  final _$SomeServiceWorkerPool _$pool;
+
+  static final Finalizer<_$SomeServiceWorkerPool> _finalizer =
+      Finalizer<_$SomeServiceWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<String> getThreadId() => _$pool.getThreadId();
+
+  @override
+  Future<String> getThreadIdFromLocal() => _$pool.getThreadIdFromLocal();
+
+  @override
+  ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(SomeServiceWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(void Function(WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(SomeServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(SomeServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(SomeServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(SomeServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 final class _$Deser extends MarshalingContext {

--- a/example/local/generated/some_service.worker.g.dart
+++ b/example/local/generated/some_service.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../some_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/local/generated/thread_identity_service.worker.g.dart
+++ b/example/local/generated/thread_identity_service.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../thread_identity_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/misc/data.freezed.dart
+++ b/example/misc/data.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -78,6 +77,163 @@ class _$DataCopyWithImpl<$Res> implements $DataCopyWith<$Res> {
           : c // ignore: cast_nullable_to_non_nullable
               as String,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Data].
+extension DataPatterns on Data {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Data value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Data() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Data value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Data():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Data value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Data() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(int a, bool b, String c)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Data() when $default != null:
+        return $default(_that.a, _that.b, _that.c);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(int a, bool b, String c) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Data():
+        return $default(_that.a, _that.b, _that.c);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(int a, bool b, String c)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Data() when $default != null:
+        return $default(_that.a, _that.b, _that.c);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/example/misc/generated/data_service.activator.g.dart
+++ b/example/misc/generated/data_service.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'data_service.stub.g.dart'

--- a/example/misc/generated/data_service.stub.g.dart
+++ b/example/misc/generated/data_service.stub.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/misc/generated/data_service.vm.g.dart
+++ b/example/misc/generated/data_service.vm.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/misc/generated/data_service.web.g.dart
+++ b/example/misc/generated/data_service.web.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/misc/generated/data_service.worker.g.dart
+++ b/example/misc/generated/data_service.worker.g.dart
@@ -54,38 +54,158 @@ WorkerService $DataServiceInitializer(WorkerRequest $req) =>
     _$DataService$WorkerService();
 
 /// Worker for DataService
-base class DataServiceWorker extends Worker
+base class _$DataServiceWorker extends Worker
     with _$DataService$Invoker, _$DataService$Facade
     implements DataService {
-  DataServiceWorker(
+  _$DataServiceWorker(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($DataServiceActivator(Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  DataServiceWorker.vm(
+  _$DataServiceWorker.vm(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($DataServiceActivator(SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  DataServiceWorker.js(
+  _$DataServiceWorker.js(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($DataServiceActivator(SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  DataServiceWorker.wasm(
+  _$DataServiceWorker.wasm(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($DataServiceActivator(SquadronPlatformType.wasm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for DataService
+base class DataServiceWorker with Releasable implements _$DataServiceWorker {
+  DataServiceWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  DataServiceWorker(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$DataServiceWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  DataServiceWorker.vm(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$DataServiceWorker.vm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  DataServiceWorker.js(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$DataServiceWorker.js(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  DataServiceWorker.wasm(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$DataServiceWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$DataServiceWorker _$worker;
+
+  static final Finalizer<_$DataServiceWorker> _finalizer =
+      Finalizer<_$DataServiceWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<Data> doSomething(Data input) => _$worker.doSomething(input);
+
+  @override
+  ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  WorkerStat get stats => _$worker.stats;
+
+  @override
+  WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 /// Worker pool for DataService
-base class DataServiceWorkerPool extends WorkerPool<DataServiceWorker>
+base class _$DataServiceWorkerPool extends WorkerPool<DataServiceWorker>
     with _$DataService$Facade
     implements DataService {
-  DataServiceWorkerPool(
+  _$DataServiceWorkerPool(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -95,7 +215,7 @@ base class DataServiceWorkerPool extends WorkerPool<DataServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  DataServiceWorkerPool.vm(
+  _$DataServiceWorkerPool.vm(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -105,7 +225,7 @@ base class DataServiceWorkerPool extends WorkerPool<DataServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  DataServiceWorkerPool.js(
+  _$DataServiceWorkerPool.js(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -115,7 +235,7 @@ base class DataServiceWorkerPool extends WorkerPool<DataServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  DataServiceWorkerPool.wasm(
+  _$DataServiceWorkerPool.wasm(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -127,6 +247,161 @@ base class DataServiceWorkerPool extends WorkerPool<DataServiceWorker>
 
   @override
   Future<Data> doSomething(Data input) => execute((w) => w.doSomething(input));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for DataService
+base class DataServiceWorkerPool
+    with Releasable
+    implements _$DataServiceWorkerPool {
+  DataServiceWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  DataServiceWorkerPool(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$DataServiceWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  DataServiceWorkerPool.vm(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$DataServiceWorkerPool.vm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  DataServiceWorkerPool.js(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$DataServiceWorkerPool.js(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  DataServiceWorkerPool.wasm(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$DataServiceWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$DataServiceWorkerPool _$pool;
+
+  static final Finalizer<_$DataServiceWorkerPool> _finalizer =
+      Finalizer<_$DataServiceWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<Data> doSomething(Data input) => _$pool.doSomething(input);
+
+  @override
+  ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(DataServiceWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(void Function(WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(DataServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(DataServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(DataServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(DataServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 final class _$Deser extends MarshalingContext {

--- a/example/misc/generated/data_service.worker.g.dart
+++ b/example/misc/generated/data_service.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../data_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map
@@ -16,13 +16,10 @@ extension on DataService {
         _$doSomethingId: ($req) async {
           final Data $res;
           try {
-            final $dsr = _$Deser(contextAware: true);
+            final $dsr = _$Deser(contextAware: false);
             $res = await doSomething($dsr.$0($req.args[0]));
           } finally {}
-          try {
-            final $sr = _$Ser(contextAware: true);
-            return $sr.$0($res);
-          } finally {}
+          return $res;
         },
       });
 }
@@ -32,13 +29,9 @@ extension on DataService {
 mixin _$DataService$Invoker on Invoker implements DataService {
   @override
   Future<Data> doSomething(Data input) async {
-    final dynamic $res;
+    final dynamic $res = await send(_$doSomethingId, args: [input]);
     try {
-      final $sr = _$Ser(contextAware: true);
-      $res = await send(_$doSomethingId, args: [$sr.$0(input)]);
-    } finally {}
-    try {
-      final $dsr = _$Deser(contextAware: true);
+      final $dsr = _$Deser(contextAware: false);
       return $dsr.$0($res);
     } finally {}
   }
@@ -138,10 +131,5 @@ base class DataServiceWorkerPool extends WorkerPool<DataServiceWorker>
 
 final class _$Deser extends MarshalingContext {
   _$Deser({super.contextAware});
-  late final $0 = (($) => ext_d.DataMarshalerExt.unmarshal($, this));
-}
-
-final class _$Ser extends MarshalingContext {
-  _$Ser({super.contextAware});
-  late final $0 = (($) => ($ as Data).marshal(this));
+  late final $0 = value<Data>();
 }

--- a/example/misc/generated/json_service.activator.g.dart
+++ b/example/misc/generated/json_service.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'json_service.stub.g.dart'

--- a/example/misc/generated/json_service.stub.g.dart
+++ b/example/misc/generated/json_service.stub.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart' as sq;

--- a/example/misc/generated/json_service.vm.g.dart
+++ b/example/misc/generated/json_service.vm.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart' as sq;

--- a/example/misc/generated/json_service.web.g.dart
+++ b/example/misc/generated/json_service.web.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart' as sq;

--- a/example/misc/generated/json_service.worker.g.dart
+++ b/example/misc/generated/json_service.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../json_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/misc/generated/json_service.worker.g.dart
+++ b/example/misc/generated/json_service.worker.g.dart
@@ -49,28 +49,28 @@ sq.WorkerService $JsonServiceInitializer(sq.WorkerRequest $req) =>
     _$JsonService$WorkerService();
 
 /// Worker for JsonService
-base class JsonServiceWorker extends sq.Worker
+base class _$JsonServiceWorker extends sq.Worker
     with _$JsonService$Invoker, _$JsonService$Facade
     implements JsonService {
-  JsonServiceWorker(
+  _$JsonServiceWorker(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($JsonServiceActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  JsonServiceWorker.vm(
+  _$JsonServiceWorker.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($JsonServiceActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  JsonServiceWorker.js(
+  _$JsonServiceWorker.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($JsonServiceActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  JsonServiceWorker.wasm(
+  _$JsonServiceWorker.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($JsonServiceActivator(sq.SquadronPlatformType.wasm),
@@ -78,13 +78,137 @@ base class JsonServiceWorker extends sq.Worker
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for JsonService
+base class JsonServiceWorker with Releasable implements _$JsonServiceWorker {
+  JsonServiceWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  JsonServiceWorker(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$JsonServiceWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  JsonServiceWorker.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$JsonServiceWorker.vm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  JsonServiceWorker.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$JsonServiceWorker.js(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  JsonServiceWorker.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$JsonServiceWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$JsonServiceWorker _$worker;
+
+  static final Finalizer<_$JsonServiceWorker> _finalizer =
+      Finalizer<_$JsonServiceWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<dynamic> decode(String source) => _$worker.decode(source);
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for JsonService
-base class JsonServiceWorkerPool extends sq.WorkerPool<JsonServiceWorker>
+base class _$JsonServiceWorkerPool extends sq.WorkerPool<JsonServiceWorker>
     with _$JsonService$Facade
     implements JsonService {
-  JsonServiceWorkerPool(
+  _$JsonServiceWorkerPool(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -94,7 +218,7 @@ base class JsonServiceWorkerPool extends sq.WorkerPool<JsonServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  JsonServiceWorkerPool.vm(
+  _$JsonServiceWorkerPool.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -104,7 +228,7 @@ base class JsonServiceWorkerPool extends sq.WorkerPool<JsonServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  JsonServiceWorkerPool.js(
+  _$JsonServiceWorkerPool.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -114,7 +238,7 @@ base class JsonServiceWorkerPool extends sq.WorkerPool<JsonServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  JsonServiceWorkerPool.wasm(
+  _$JsonServiceWorkerPool.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -126,6 +250,162 @@ base class JsonServiceWorkerPool extends sq.WorkerPool<JsonServiceWorker>
 
   @override
   Future<dynamic> decode(String source) => execute((w) => w.decode(source));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for JsonService
+base class JsonServiceWorkerPool
+    with Releasable
+    implements _$JsonServiceWorkerPool {
+  JsonServiceWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  JsonServiceWorkerPool(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$JsonServiceWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  JsonServiceWorkerPool.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$JsonServiceWorkerPool.vm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  JsonServiceWorkerPool.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$JsonServiceWorkerPool.js(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  JsonServiceWorkerPool.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$JsonServiceWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$JsonServiceWorkerPool _$pool;
+
+  static final Finalizer<_$JsonServiceWorkerPool> _finalizer =
+      Finalizer<_$JsonServiceWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<dynamic> decode(String source) => _$pool.decode(source);
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(JsonServiceWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(JsonServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(JsonServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(JsonServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(JsonServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 final class _$Deser extends sq.MarshalingContext {

--- a/example/misc/generated/sample_service.activator.g.dart
+++ b/example/misc/generated/sample_service.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'sample_service.stub.g.dart'

--- a/example/misc/generated/sample_service.stub.g.dart
+++ b/example/misc/generated/sample_service.stub.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/misc/generated/sample_service.vm.g.dart
+++ b/example/misc/generated/sample_service.vm.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/misc/generated/sample_service.web.g.dart
+++ b/example/misc/generated/sample_service.web.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/misc/generated/sample_service.worker.g.dart
+++ b/example/misc/generated/sample_service.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../sample_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/misc/generated/sample_service.worker.g.dart
+++ b/example/misc/generated/sample_service.worker.g.dart
@@ -62,38 +62,161 @@ WorkerService $SampleServiceInitializer(WorkerRequest $req) =>
     _$SampleService$WorkerService();
 
 /// Worker for SampleService
-base class SampleServiceWorker extends Worker
+base class _$SampleServiceWorker extends Worker
     with _$SampleService$Invoker, _$SampleService$Facade
     implements SampleService {
-  SampleServiceWorker(
+  _$SampleServiceWorker(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($SampleServiceActivator(Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  SampleServiceWorker.vm(
+  _$SampleServiceWorker.vm(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($SampleServiceActivator(SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  SampleServiceWorker.js(
+  _$SampleServiceWorker.js(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($SampleServiceActivator(SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  SampleServiceWorker.wasm(
+  _$SampleServiceWorker.wasm(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($SampleServiceActivator(SquadronPlatformType.wasm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for SampleService
+base class SampleServiceWorker
+    with Releasable
+    implements _$SampleServiceWorker {
+  SampleServiceWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  SampleServiceWorker(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$SampleServiceWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  SampleServiceWorker.vm(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$SampleServiceWorker.vm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  SampleServiceWorker.js(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$SampleServiceWorker.js(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  SampleServiceWorker.wasm(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$SampleServiceWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$SampleServiceWorker _$worker;
+
+  static final Finalizer<_$SampleServiceWorker> _finalizer =
+      Finalizer<_$SampleServiceWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<DataOut> compute(DataIn input, State state) =>
+      _$worker.compute(input, state);
+
+  @override
+  ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  WorkerStat get stats => _$worker.stats;
+
+  @override
+  WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 /// Worker pool for SampleService
-base class SampleServiceWorkerPool extends WorkerPool<SampleServiceWorker>
+base class _$SampleServiceWorkerPool extends WorkerPool<SampleServiceWorker>
     with _$SampleService$Facade
     implements SampleService {
-  SampleServiceWorkerPool(
+  _$SampleServiceWorkerPool(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -103,7 +226,7 @@ base class SampleServiceWorkerPool extends WorkerPool<SampleServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  SampleServiceWorkerPool.vm(
+  _$SampleServiceWorkerPool.vm(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -113,7 +236,7 @@ base class SampleServiceWorkerPool extends WorkerPool<SampleServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  SampleServiceWorkerPool.js(
+  _$SampleServiceWorkerPool.js(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -123,7 +246,7 @@ base class SampleServiceWorkerPool extends WorkerPool<SampleServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  SampleServiceWorkerPool.wasm(
+  _$SampleServiceWorkerPool.wasm(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -136,6 +259,162 @@ base class SampleServiceWorkerPool extends WorkerPool<SampleServiceWorker>
   @override
   Future<DataOut> compute(DataIn input, State state) =>
       execute((w) => w.compute(input, state));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for SampleService
+base class SampleServiceWorkerPool
+    with Releasable
+    implements _$SampleServiceWorkerPool {
+  SampleServiceWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  SampleServiceWorkerPool(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$SampleServiceWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  SampleServiceWorkerPool.vm(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$SampleServiceWorkerPool.vm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  SampleServiceWorkerPool.js(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$SampleServiceWorkerPool.js(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  SampleServiceWorkerPool.wasm(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$SampleServiceWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$SampleServiceWorkerPool _$pool;
+
+  static final Finalizer<_$SampleServiceWorkerPool> _finalizer =
+      Finalizer<_$SampleServiceWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<DataOut> compute(DataIn input, State state) =>
+      _$pool.compute(input, state);
+
+  @override
+  ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(SampleServiceWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(void Function(WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(SampleServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(SampleServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(SampleServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(SampleServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 final class _$Deser extends MarshalingContext {

--- a/example/misc_wasm/generated/data_service.activator.g.dart
+++ b/example/misc_wasm/generated/data_service.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'data_service.web.g.dart';

--- a/example/misc_wasm/generated/data_service.web.g.dart
+++ b/example/misc_wasm/generated/data_service.web.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/misc_wasm/generated/data_service.worker.g.dart
+++ b/example/misc_wasm/generated/data_service.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../data_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/misc_wasm/generated/data_service.worker.g.dart
+++ b/example/misc_wasm/generated/data_service.worker.g.dart
@@ -61,28 +61,138 @@ WorkerService $DataServiceInitializer(WorkerRequest $req) =>
     _$DataService$WorkerService();
 
 /// Worker for DataService
-base class DataServiceWorker extends Worker
+base class _$DataServiceWorker extends Worker
     with _$DataService$Invoker, _$DataService$Facade
     implements DataService {
-  DataServiceWorker(
+  _$DataServiceWorker(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($DataServiceActivator(Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  DataServiceWorker.wasm(
+  _$DataServiceWorker.wasm(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($DataServiceActivator(SquadronPlatformType.wasm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for DataService
+base class DataServiceWorker with Releasable implements _$DataServiceWorker {
+  DataServiceWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  DataServiceWorker(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$DataServiceWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  DataServiceWorker.wasm(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$DataServiceWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$DataServiceWorker _$worker;
+
+  static final Finalizer<_$DataServiceWorker> _finalizer =
+      Finalizer<_$DataServiceWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<Data> doSomething(Data input) => _$worker.doSomething(input);
+
+  @override
+  ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  WorkerStat get stats => _$worker.stats;
+
+  @override
+  WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 /// Worker pool for DataService
-base class DataServiceWorkerPool extends WorkerPool<DataServiceWorker>
+base class _$DataServiceWorkerPool extends WorkerPool<DataServiceWorker>
     with _$DataService$Facade
     implements DataService {
-  DataServiceWorkerPool(
+  _$DataServiceWorkerPool(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -92,7 +202,7 @@ base class DataServiceWorkerPool extends WorkerPool<DataServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  DataServiceWorkerPool.wasm(
+  _$DataServiceWorkerPool.wasm(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -104,6 +214,143 @@ base class DataServiceWorkerPool extends WorkerPool<DataServiceWorker>
 
   @override
   Future<Data> doSomething(Data input) => execute((w) => w.doSomething(input));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for DataService
+base class DataServiceWorkerPool
+    with Releasable
+    implements _$DataServiceWorkerPool {
+  DataServiceWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  DataServiceWorkerPool(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$DataServiceWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  DataServiceWorkerPool.wasm(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$DataServiceWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$DataServiceWorkerPool _$pool;
+
+  static final Finalizer<_$DataServiceWorkerPool> _finalizer =
+      Finalizer<_$DataServiceWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<Data> doSomething(Data input) => _$pool.doSomething(input);
+
+  @override
+  ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(DataServiceWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(void Function(WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(DataServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(DataServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(DataServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(DataServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 final class _$Deser extends MarshalingContext {

--- a/example/misc_wasm/generated/json_service.activator.g.dart
+++ b/example/misc_wasm/generated/json_service.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'json_service.web.g.dart';

--- a/example/misc_wasm/generated/json_service.web.g.dart
+++ b/example/misc_wasm/generated/json_service.web.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart' as sq;

--- a/example/misc_wasm/generated/json_service.worker.g.dart
+++ b/example/misc_wasm/generated/json_service.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../json_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/misc_wasm/generated/json_service.worker.g.dart
+++ b/example/misc_wasm/generated/json_service.worker.g.dart
@@ -49,16 +49,16 @@ sq.WorkerService $JsonServiceInitializer(sq.WorkerRequest $req) =>
     _$JsonService$WorkerService();
 
 /// Worker for JsonService
-base class JsonServiceWorker extends sq.Worker
+base class _$JsonServiceWorker extends sq.Worker
     with _$JsonService$Invoker, _$JsonService$Facade
     implements JsonService {
-  JsonServiceWorker(
+  _$JsonServiceWorker(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($JsonServiceActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  JsonServiceWorker.wasm(
+  _$JsonServiceWorker.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($JsonServiceActivator(sq.SquadronPlatformType.wasm),
@@ -66,13 +66,125 @@ base class JsonServiceWorker extends sq.Worker
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for JsonService
+base class JsonServiceWorker with Releasable implements _$JsonServiceWorker {
+  JsonServiceWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  JsonServiceWorker(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$JsonServiceWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  JsonServiceWorker.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$JsonServiceWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$JsonServiceWorker _$worker;
+
+  static final Finalizer<_$JsonServiceWorker> _finalizer =
+      Finalizer<_$JsonServiceWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<dynamic> decode(String source) => _$worker.decode(source);
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for JsonService
-base class JsonServiceWorkerPool extends sq.WorkerPool<JsonServiceWorker>
+base class _$JsonServiceWorkerPool extends sq.WorkerPool<JsonServiceWorker>
     with _$JsonService$Facade
     implements JsonService {
-  JsonServiceWorkerPool(
+  _$JsonServiceWorkerPool(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -82,7 +194,7 @@ base class JsonServiceWorkerPool extends sq.WorkerPool<JsonServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  JsonServiceWorkerPool.wasm(
+  _$JsonServiceWorkerPool.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -94,6 +206,144 @@ base class JsonServiceWorkerPool extends sq.WorkerPool<JsonServiceWorker>
 
   @override
   Future<dynamic> decode(String source) => execute((w) => w.decode(source));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for JsonService
+base class JsonServiceWorkerPool
+    with Releasable
+    implements _$JsonServiceWorkerPool {
+  JsonServiceWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  JsonServiceWorkerPool(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$JsonServiceWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  JsonServiceWorkerPool.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$JsonServiceWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$JsonServiceWorkerPool _$pool;
+
+  static final Finalizer<_$JsonServiceWorkerPool> _finalizer =
+      Finalizer<_$JsonServiceWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<dynamic> decode(String source) => _$pool.decode(source);
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(JsonServiceWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(JsonServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(JsonServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(JsonServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(JsonServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 final class _$Deser extends sq.MarshalingContext {

--- a/example/misc_wasm/generated/sample_service.activator.g.dart
+++ b/example/misc_wasm/generated/sample_service.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'sample_service.web.g.dart';

--- a/example/misc_wasm/generated/sample_service.web.g.dart
+++ b/example/misc_wasm/generated/sample_service.web.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/misc_wasm/generated/sample_service.worker.g.dart
+++ b/example/misc_wasm/generated/sample_service.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../sample_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/misc_wasm/generated/sample_service.worker.g.dart
+++ b/example/misc_wasm/generated/sample_service.worker.g.dart
@@ -62,28 +62,140 @@ WorkerService $SampleServiceInitializer(WorkerRequest $req) =>
     _$SampleService$WorkerService();
 
 /// Worker for SampleService
-base class SampleServiceWorker extends Worker
+base class _$SampleServiceWorker extends Worker
     with _$SampleService$Invoker, _$SampleService$Facade
     implements SampleService {
-  SampleServiceWorker(
+  _$SampleServiceWorker(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($SampleServiceActivator(Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  SampleServiceWorker.wasm(
+  _$SampleServiceWorker.wasm(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($SampleServiceActivator(SquadronPlatformType.wasm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for SampleService
+base class SampleServiceWorker
+    with Releasable
+    implements _$SampleServiceWorker {
+  SampleServiceWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  SampleServiceWorker(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$SampleServiceWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  SampleServiceWorker.wasm(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$SampleServiceWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$SampleServiceWorker _$worker;
+
+  static final Finalizer<_$SampleServiceWorker> _finalizer =
+      Finalizer<_$SampleServiceWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<DataOut> compute(DataIn input) => _$worker.compute(input);
+
+  @override
+  ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  WorkerStat get stats => _$worker.stats;
+
+  @override
+  WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 /// Worker pool for SampleService
-base class SampleServiceWorkerPool extends WorkerPool<SampleServiceWorker>
+base class _$SampleServiceWorkerPool extends WorkerPool<SampleServiceWorker>
     with _$SampleService$Facade
     implements SampleService {
-  SampleServiceWorkerPool(
+  _$SampleServiceWorkerPool(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -93,7 +205,7 @@ base class SampleServiceWorkerPool extends WorkerPool<SampleServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  SampleServiceWorkerPool.wasm(
+  _$SampleServiceWorkerPool.wasm(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -105,6 +217,143 @@ base class SampleServiceWorkerPool extends WorkerPool<SampleServiceWorker>
 
   @override
   Future<DataOut> compute(DataIn input) => execute((w) => w.compute(input));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for SampleService
+base class SampleServiceWorkerPool
+    with Releasable
+    implements _$SampleServiceWorkerPool {
+  SampleServiceWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  SampleServiceWorkerPool(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$SampleServiceWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  SampleServiceWorkerPool.wasm(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$SampleServiceWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$SampleServiceWorkerPool _$pool;
+
+  static final Finalizer<_$SampleServiceWorkerPool> _finalizer =
+      Finalizer<_$SampleServiceWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<DataOut> compute(DataIn input) => _$pool.compute(input);
+
+  @override
+  ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(SampleServiceWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(void Function(WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(SampleServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(SampleServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(SampleServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(SampleServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 final class _$Deser extends MarshalingContext {

--- a/example/perf/echo_service.dart
+++ b/example/perf/echo_service.dart
@@ -11,7 +11,9 @@ import 'generated/echo_service.activator.g.dart';
 import 'marshalers.dart';
 import 'service_config.dart' as cfg;
 import 'service_request.dart' as srv;
+import 'service_request.dart';
 import 'service_response.dart' as srv;
+import 'service_response.dart';
 
 part 'generated/echo_service.worker.g.dart';
 

--- a/example/perf/echo_service.dart
+++ b/example/perf/echo_service.dart
@@ -11,9 +11,7 @@ import 'generated/echo_service.activator.g.dart';
 import 'marshalers.dart';
 import 'service_config.dart' as cfg;
 import 'service_request.dart' as srv;
-import 'service_request.dart';
 import 'service_response.dart' as srv;
-import 'service_response.dart';
 
 part 'generated/echo_service.worker.g.dart';
 

--- a/example/perf/generated/echo_service.activator.g.dart
+++ b/example/perf/generated/echo_service.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'echo_service.vm.g.dart';

--- a/example/perf/generated/echo_service.vm.g.dart
+++ b/example/perf/generated/echo_service.vm.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart' as sq;

--- a/example/perf/generated/echo_service.worker.g.dart
+++ b/example/perf/generated/echo_service.worker.g.dart
@@ -190,10 +190,10 @@ sq.WorkerService $EchoServiceInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for EchoService
-base class EchoServiceWorker extends sq.Worker
+base class _$EchoServiceWorker extends sq.Worker
     with _$EchoService$Invoker, _$EchoService$Facade
     implements EchoService {
-  EchoServiceWorker(
+  _$EchoServiceWorker(
       [bool trace = false,
       cfg.ServiceConfig<int>? workloadDelay,
       sq.PlatformThreadHook? threadHook,
@@ -205,7 +205,7 @@ base class EchoServiceWorker extends sq.Worker
         super($EchoServiceActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  EchoServiceWorker.vm(
+  _$EchoServiceWorker.vm(
       [bool trace = false,
       cfg.ServiceConfig<int>? workloadDelay,
       sq.PlatformThreadHook? threadHook,
@@ -221,13 +221,165 @@ base class EchoServiceWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for EchoService
+base class EchoServiceWorker with Releasable implements _$EchoServiceWorker {
+  EchoServiceWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  EchoServiceWorker(
+      [bool trace = false,
+      cfg.ServiceConfig<int>? workloadDelay,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$EchoServiceWorker(
+            trace, workloadDelay, threadHook, exceptionManager));
+
+  EchoServiceWorker.vm(
+      [bool trace = false,
+      cfg.ServiceConfig<int>? workloadDelay,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$EchoServiceWorker.vm(
+            trace, workloadDelay, threadHook, exceptionManager));
+
+  final _$EchoServiceWorker _$worker;
+
+  static final Finalizer<_$EchoServiceWorker> _finalizer =
+      Finalizer<_$EchoServiceWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  xxx.Future<srv.ServiceResponse<String>> explicitEchoWithExplicitResult(
+          srv.ServiceRequest request,
+          {CancelationToken? token}) =>
+      _$worker.explicitEchoWithExplicitResult(request, token: token);
+
+  @override
+  xxx.Future<srv.ServiceResponse<String>> explicitEchoWithJsonResult(
+          srv.ServiceRequest request) =>
+      _$worker.explicitEchoWithJsonResult(request);
+
+  @override
+  xxx.Future<srv.ServiceResponse<String>> jsonEchoWithExplicitResult(
+          srv.ServiceRequest request) =>
+      _$worker.jsonEchoWithExplicitResult(request);
+
+  @override
+  xxx.Future<srv.ServiceResponse<String>?> jsonEchoWithJsonResult(
+          srv.ServiceRequest request) =>
+      _$worker.jsonEchoWithJsonResult(request);
+
+  @override
+  xxx.Future<srv.ServiceResponse<String>> jsonEncodeEcho(
+          srv.ServiceRequest request,
+          [CancelationToken? token]) =>
+      _$worker.jsonEncodeEcho(request, token);
+
+  @override
+  void _simulateWorkload() => _$worker._simulateWorkload();
+
+  @override
+  Logger? get _logger => _$worker._logger;
+
+  @override
+  Duration get _delay => _$worker._delay;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  xxx.Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  xxx.Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  xxx.Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for EchoService
-base class EchoServiceWorkerPool extends sq.WorkerPool<EchoServiceWorker>
+base class _$EchoServiceWorkerPool extends sq.WorkerPool<EchoServiceWorker>
     with _$EchoService$Facade
     implements EchoService {
-  EchoServiceWorkerPool(
+  _$EchoServiceWorkerPool(
       [bool trace = false,
       cfg.ServiceConfig<int>? workloadDelay,
       sq.PlatformThreadHook? threadHook,
@@ -239,7 +391,7 @@ base class EchoServiceWorkerPool extends sq.WorkerPool<EchoServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  EchoServiceWorkerPool.vm(
+  _$EchoServiceWorkerPool.vm(
       [bool trace = false,
       cfg.ServiceConfig<int>? workloadDelay,
       sq.PlatformThreadHook? threadHook,
@@ -277,6 +429,178 @@ base class EchoServiceWorkerPool extends sq.WorkerPool<EchoServiceWorker>
           srv.ServiceRequest request,
           [CancelationToken? token]) =>
       execute((w) => w.jsonEncodeEcho(request, token));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for EchoService
+base class EchoServiceWorkerPool
+    with Releasable
+    implements _$EchoServiceWorkerPool {
+  EchoServiceWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  EchoServiceWorkerPool(
+      [bool trace = false,
+      cfg.ServiceConfig<int>? workloadDelay,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$EchoServiceWorkerPool(trace, workloadDelay, threadHook,
+            exceptionManager, concurrencySettings));
+
+  EchoServiceWorkerPool.vm(
+      [bool trace = false,
+      cfg.ServiceConfig<int>? workloadDelay,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$EchoServiceWorkerPool.vm(trace, workloadDelay, threadHook,
+            exceptionManager, concurrencySettings));
+
+  final _$EchoServiceWorkerPool _$pool;
+
+  static final Finalizer<_$EchoServiceWorkerPool> _finalizer =
+      Finalizer<_$EchoServiceWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  xxx.Future<srv.ServiceResponse<String>> explicitEchoWithExplicitResult(
+          srv.ServiceRequest request,
+          {CancelationToken? token}) =>
+      _$pool.explicitEchoWithExplicitResult(request, token: token);
+
+  @override
+  xxx.Future<srv.ServiceResponse<String>> explicitEchoWithJsonResult(
+          srv.ServiceRequest request) =>
+      _$pool.explicitEchoWithJsonResult(request);
+
+  @override
+  xxx.Future<srv.ServiceResponse<String>> jsonEchoWithExplicitResult(
+          srv.ServiceRequest request) =>
+      _$pool.jsonEchoWithExplicitResult(request);
+
+  @override
+  xxx.Future<srv.ServiceResponse<String>?> jsonEchoWithJsonResult(
+          srv.ServiceRequest request) =>
+      _$pool.jsonEchoWithJsonResult(request);
+
+  @override
+  xxx.Future<srv.ServiceResponse<String>> jsonEncodeEcho(
+          srv.ServiceRequest request,
+          [CancelationToken? token]) =>
+      _$pool.jsonEncodeEcho(request, token);
+
+  @override
+  void _simulateWorkload() => _$pool._simulateWorkload();
+
+  @override
+  Logger? get _logger => _$pool._logger;
+
+  @override
+  Duration get _delay => _$pool._delay;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  xxx.FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(EchoServiceWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  xxx.Future<T> execute<T>(
+          xxx.Future<T> Function(EchoServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  xxx.Stream<T> stream<T>(xxx.Stream<T> Function(EchoServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          xxx.Stream<T> Function(EchoServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          xxx.Future<T> Function(EchoServiceWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 final class _$Deser extends sq.MarshalingContext {

--- a/example/perf/generated/echo_service.worker.g.dart
+++ b/example/perf/generated/echo_service.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../echo_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/perf/generated/fibonacci_service.activator.g.dart
+++ b/example/perf/generated/fibonacci_service.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'fibonacci_service.vm.g.dart';

--- a/example/perf/generated/fibonacci_service.vm.g.dart
+++ b/example/perf/generated/fibonacci_service.vm.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/perf/generated/fibonacci_service.worker.g.dart
+++ b/example/perf/generated/fibonacci_service.worker.g.dart
@@ -144,10 +144,10 @@ WorkerService $FibonacciServiceInitializer(WorkerRequest $req) {
 }
 
 /// Worker for FibonacciService
-base class FibonacciServiceWorker extends Worker
+base class _$FibonacciServiceWorker extends Worker
     with _$FibonacciService$Invoker, _$FibonacciService$Facade
     implements FibonacciService {
-  FibonacciServiceWorker(
+  _$FibonacciServiceWorker(
       {bool trace = false,
       PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager})
@@ -155,7 +155,7 @@ base class FibonacciServiceWorker extends Worker
         super($FibonacciServiceActivator(Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  FibonacciServiceWorker.vm(
+  _$FibonacciServiceWorker.vm(
       {bool trace = false,
       PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager})
@@ -167,13 +167,156 @@ base class FibonacciServiceWorker extends Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for FibonacciService
+base class FibonacciServiceWorker
+    with Releasable
+    implements _$FibonacciServiceWorker {
+  FibonacciServiceWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  FibonacciServiceWorker(
+      {bool trace = false,
+      PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager})
+      : this._(_$FibonacciServiceWorker(
+            trace: trace,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  FibonacciServiceWorker.vm(
+      {bool trace = false,
+      PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager})
+      : this._(_$FibonacciServiceWorker.vm(
+            trace: trace,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  final _$FibonacciServiceWorker _$worker;
+
+  static final Finalizer<_$FibonacciServiceWorker> _finalizer =
+      Finalizer<_$FibonacciServiceWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<int?> fibonacci(int i) => _$worker.fibonacci(i);
+
+  @override
+  Future<Iterable<int>?> fibonacciList0(int s, int e) =>
+      _$worker.fibonacciList0(s, e);
+
+  @override
+  Future<List<int>> fibonacciList1(int s, int e) =>
+      _$worker.fibonacciList1(s, e);
+
+  @override
+  Future<List<int>> fibonacciList2(int s, int e) =>
+      _$worker.fibonacciList2(s, e);
+
+  @override
+  Stream<int> fibonacciStream(int start, {int? end, CancelationToken? token}) =>
+      _$worker.fibonacciStream(start, end: end, token: token);
+
+  @override
+  Logger? get _logger => _$worker._logger;
+
+  @override
+  ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  WorkerStat get stats => _$worker.stats;
+
+  @override
+  WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 /// Worker pool for FibonacciService
-base class FibonacciServiceWorkerPool extends WorkerPool<FibonacciServiceWorker>
+base class _$FibonacciServiceWorkerPool
+    extends WorkerPool<FibonacciServiceWorker>
     with _$FibonacciService$Facade
     implements FibonacciService {
-  FibonacciServiceWorkerPool(
+  _$FibonacciServiceWorkerPool(
       {bool trace = false,
       PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
@@ -186,7 +329,7 @@ base class FibonacciServiceWorkerPool extends WorkerPool<FibonacciServiceWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  FibonacciServiceWorkerPool.vm(
+  _$FibonacciServiceWorkerPool.vm(
       {bool trace = false,
       PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
@@ -217,6 +360,164 @@ base class FibonacciServiceWorkerPool extends WorkerPool<FibonacciServiceWorker>
   @override
   Stream<int> fibonacciStream(int start, {int? end, CancelationToken? token}) =>
       stream((w) => w.fibonacciStream(start, end: end, token: token));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for FibonacciService
+base class FibonacciServiceWorkerPool
+    with Releasable
+    implements _$FibonacciServiceWorkerPool {
+  FibonacciServiceWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  FibonacciServiceWorkerPool(
+      {bool trace = false,
+      PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$FibonacciServiceWorkerPool(
+            trace: trace,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  FibonacciServiceWorkerPool.vm(
+      {bool trace = false,
+      PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$FibonacciServiceWorkerPool.vm(
+            trace: trace,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$FibonacciServiceWorkerPool _$pool;
+
+  static final Finalizer<_$FibonacciServiceWorkerPool> _finalizer =
+      Finalizer<_$FibonacciServiceWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<int?> fibonacci(int i) => _$pool.fibonacci(i);
+
+  @override
+  Future<Iterable<int>?> fibonacciList0(int s, int e) =>
+      _$pool.fibonacciList0(s, e);
+
+  @override
+  Future<List<int>> fibonacciList1(int s, int e) => _$pool.fibonacciList1(s, e);
+
+  @override
+  Future<List<int>> fibonacciList2(int s, int e) => _$pool.fibonacciList2(s, e);
+
+  @override
+  Stream<int> fibonacciStream(int start, {int? end, CancelationToken? token}) =>
+      _$pool.fibonacciStream(start, end: end, token: token);
+
+  @override
+  Logger? get _logger => _$pool._logger;
+
+  @override
+  ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(FibonacciServiceWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(void Function(WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(FibonacciServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(FibonacciServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(FibonacciServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(FibonacciServiceWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 final class _$Deser extends MarshalingContext {

--- a/example/perf/generated/fibonacci_service.worker.g.dart
+++ b/example/perf/generated/fibonacci_service.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../fibonacci_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/streaming/generated/clock.activator.g.dart
+++ b/example/streaming/generated/clock.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'clock.stub.g.dart'

--- a/example/streaming/generated/clock.stub.g.dart
+++ b/example/streaming/generated/clock.stub.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/streaming/generated/clock.vm.g.dart
+++ b/example/streaming/generated/clock.vm.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/streaming/generated/clock.web.g.dart
+++ b/example/streaming/generated/clock.web.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/streaming/generated/clock.worker.g.dart
+++ b/example/streaming/generated/clock.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../clock.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/example/streaming/generated/clock.worker.g.dart
+++ b/example/streaming/generated/clock.worker.g.dart
@@ -55,38 +55,159 @@ class _$Clock$WorkerService extends Clock implements WorkerService {
 WorkerService $ClockInitializer(WorkerRequest $req) => _$Clock$WorkerService();
 
 /// Worker for Clock
-base class ClockWorker extends Worker
+base class _$ClockWorker extends Worker
     with _$Clock$Invoker, _$Clock$Facade
     implements Clock {
-  ClockWorker(
+  _$ClockWorker(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($ClockActivator(Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  ClockWorker.vm(
+  _$ClockWorker.vm(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($ClockActivator(SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  ClockWorker.js(
+  _$ClockWorker.js(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($ClockActivator(SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  ClockWorker.wasm(
+  _$ClockWorker.wasm(
       {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
       : super($ClockActivator(SquadronPlatformType.wasm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for Clock
+base class ClockWorker with Releasable implements _$ClockWorker {
+  ClockWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  ClockWorker(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$ClockWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  ClockWorker.vm(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$ClockWorker.vm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  ClockWorker.js(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$ClockWorker.js(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  ClockWorker.wasm(
+      {PlatformThreadHook? threadHook, ExceptionManager? exceptionManager})
+      : this._(_$ClockWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$ClockWorker _$worker;
+
+  static final Finalizer<_$ClockWorker> _finalizer =
+      Finalizer<_$ClockWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Stream<int> infiniteClock({int periodInMs = 1000, ConsoleColor? color}) =>
+      _$worker.infiniteClock(periodInMs: periodInMs, color: color);
+
+  @override
+  ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  WorkerStat get stats => _$worker.stats;
+
+  @override
+  WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 /// Worker pool for Clock
-base class ClockWorkerPool extends WorkerPool<ClockWorker>
+base class _$ClockWorkerPool extends WorkerPool<ClockWorker>
     with _$Clock$Facade
     implements Clock {
-  ClockWorkerPool(
+  _$ClockWorkerPool(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -96,7 +217,7 @@ base class ClockWorkerPool extends WorkerPool<ClockWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  ClockWorkerPool.vm(
+  _$ClockWorkerPool.vm(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -106,7 +227,7 @@ base class ClockWorkerPool extends WorkerPool<ClockWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  ClockWorkerPool.js(
+  _$ClockWorkerPool.js(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -116,7 +237,7 @@ base class ClockWorkerPool extends WorkerPool<ClockWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  ClockWorkerPool.wasm(
+  _$ClockWorkerPool.wasm(
       {PlatformThreadHook? threadHook,
       ExceptionManager? exceptionManager,
       ConcurrencySettings? concurrencySettings})
@@ -129,6 +250,159 @@ base class ClockWorkerPool extends WorkerPool<ClockWorker>
   @override
   Stream<int> infiniteClock({int periodInMs = 1000, ConsoleColor? color}) =>
       stream((w) => w.infiniteClock(periodInMs: periodInMs, color: color));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for Clock
+base class ClockWorkerPool with Releasable implements _$ClockWorkerPool {
+  ClockWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  ClockWorkerPool(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$ClockWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  ClockWorkerPool.vm(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$ClockWorkerPool.vm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  ClockWorkerPool.js(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$ClockWorkerPool.js(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  ClockWorkerPool.wasm(
+      {PlatformThreadHook? threadHook,
+      ExceptionManager? exceptionManager,
+      ConcurrencySettings? concurrencySettings})
+      : this._(_$ClockWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$ClockWorkerPool _$pool;
+
+  static final Finalizer<_$ClockWorkerPool> _finalizer =
+      Finalizer<_$ClockWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Stream<int> infiniteClock({int periodInMs = 1000, ConsoleColor? color}) =>
+      _$pool.infiniteClock(periodInMs: periodInMs, color: color);
+
+  @override
+  ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(ClockWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(void Function(WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(ClockWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(ClockWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(ClockWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  ValueTask<T> scheduleValueTask<T>(Future<T> Function(ClockWorker worker) task,
+          {PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final OperationsMap operations = WorkerService.noOperations;
 }
 
 final class _$Deser extends MarshalingContext {

--- a/example/test/generated/test_services.activator.g.dart
+++ b/example/test/generated/test_services.activator.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'test_services.stub.g.dart'

--- a/example/test/generated/test_services.stub.g.dart
+++ b/example/test/generated/test_services.stub.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart' as sq;

--- a/example/test/generated/test_services.vm.g.dart
+++ b/example/test/generated/test_services.vm.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart' as sq;

--- a/example/test/generated/test_services.web.g.dart
+++ b/example/test/generated/test_services.web.g.dart
@@ -2,7 +2,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart' as sq;

--- a/example/test/generated/test_services.worker.g.dart
+++ b/example/test/generated/test_services.worker.g.dart
@@ -36,28 +36,28 @@ sq.WorkerService $TestParameterLessInitializer(sq.WorkerRequest $req) =>
     _$TestParameterLess$WorkerService();
 
 /// Worker for TestParameterLess
-base class TestParameterLessWorker extends sq.Worker
+base class _$TestParameterLessWorker extends sq.Worker
     with _$TestParameterLess$Invoker, _$TestParameterLess$Facade
     implements TestParameterLess {
-  TestParameterLessWorker(
+  _$TestParameterLessWorker(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestParameterLessActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestParameterLessWorker.vm(
+  _$TestParameterLessWorker.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestParameterLessActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestParameterLessWorker.js(
+  _$TestParameterLessWorker.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestParameterLessActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestParameterLessWorker.wasm(
+  _$TestParameterLessWorker.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestParameterLessActivator(sq.SquadronPlatformType.wasm),
@@ -65,14 +65,137 @@ base class TestParameterLessWorker extends sq.Worker
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestParameterLess
+base class TestParameterLessWorker
+    with Releasable
+    implements _$TestParameterLessWorker {
+  TestParameterLessWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestParameterLessWorker(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestParameterLessWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestParameterLessWorker.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestParameterLessWorker.vm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestParameterLessWorker.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestParameterLessWorker.js(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestParameterLessWorker.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestParameterLessWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$TestParameterLessWorker _$worker;
+
+  static final Finalizer<_$TestParameterLessWorker> _finalizer =
+      Finalizer<_$TestParameterLessWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestParameterLess
-base class TestParameterLessWorkerPool
+base class _$TestParameterLessWorkerPool
     extends sq.WorkerPool<TestParameterLessWorker>
     with _$TestParameterLess$Facade
     implements TestParameterLess {
-  TestParameterLessWorkerPool(
+  _$TestParameterLessWorkerPool(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -82,7 +205,7 @@ base class TestParameterLessWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestParameterLessWorkerPool.vm(
+  _$TestParameterLessWorkerPool.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -93,7 +216,7 @@ base class TestParameterLessWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestParameterLessWorkerPool.js(
+  _$TestParameterLessWorkerPool.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -104,7 +227,7 @@ base class TestParameterLessWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestParameterLessWorkerPool.wasm(
+  _$TestParameterLessWorkerPool.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -114,6 +237,159 @@ base class TestParameterLessWorkerPool
                     threadHook: threadHook, exceptionManager: exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestParameterLess
+base class TestParameterLessWorkerPool
+    with Releasable
+    implements _$TestParameterLessWorkerPool {
+  TestParameterLessWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestParameterLessWorkerPool(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestParameterLessWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestParameterLessWorkerPool.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestParameterLessWorkerPool.vm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestParameterLessWorkerPool.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestParameterLessWorkerPool.js(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestParameterLessWorkerPool.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestParameterLessWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestParameterLessWorkerPool _$pool;
+
+  static final Finalizer<_$TestParameterLessWorkerPool> _finalizer =
+      Finalizer<_$TestParameterLessWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestParameterLessWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(TestParameterLessWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(TestParameterLessWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestParameterLessWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestParameterLessWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -147,31 +423,31 @@ sq.WorkerService $TestReqPositionalInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestReqPositional
-base class TestReqPositionalWorker extends sq.Worker
+base class _$TestReqPositionalWorker extends sq.Worker
     with _$TestReqPositional$Invoker, _$TestReqPositional$Facade
     implements TestReqPositional {
-  TestReqPositionalWorker(int arg1,
+  _$TestReqPositionalWorker(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
         super($TestReqPositionalActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestReqPositionalWorker.vm(int arg1,
+  _$TestReqPositionalWorker.vm(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
         super($TestReqPositionalActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestReqPositionalWorker.js(int arg1,
+  _$TestReqPositionalWorker.js(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
         super($TestReqPositionalActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestReqPositionalWorker.wasm(int arg1,
+  _$TestReqPositionalWorker.wasm(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
@@ -182,14 +458,140 @@ base class TestReqPositionalWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestReqPositional
+base class TestReqPositionalWorker
+    with Releasable
+    implements _$TestReqPositionalWorker {
+  TestReqPositionalWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestReqPositionalWorker(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalWorker(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestReqPositionalWorker.vm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalWorker.vm(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestReqPositionalWorker.js(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalWorker.js(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestReqPositionalWorker.wasm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalWorker.wasm(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$TestReqPositionalWorker _$worker;
+
+  static final Finalizer<_$TestReqPositionalWorker> _finalizer =
+      Finalizer<_$TestReqPositionalWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestReqPositional
-base class TestReqPositionalWorkerPool
+base class _$TestReqPositionalWorkerPool
     extends sq.WorkerPool<TestReqPositionalWorker>
     with _$TestReqPositional$Facade
     implements TestReqPositional {
-  TestReqPositionalWorkerPool(int arg1,
+  _$TestReqPositionalWorkerPool(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -201,7 +603,7 @@ base class TestReqPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestReqPositionalWorkerPool.vm(int arg1,
+  _$TestReqPositionalWorkerPool.vm(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -212,7 +614,7 @@ base class TestReqPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestReqPositionalWorkerPool.js(int arg1,
+  _$TestReqPositionalWorkerPool.js(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -223,7 +625,7 @@ base class TestReqPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestReqPositionalWorkerPool.wasm(int arg1,
+  _$TestReqPositionalWorkerPool.wasm(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -233,6 +635,159 @@ base class TestReqPositionalWorkerPool
                     threadHook: threadHook, exceptionManager: exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestReqPositional
+base class TestReqPositionalWorkerPool
+    with Releasable
+    implements _$TestReqPositionalWorkerPool {
+  TestReqPositionalWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestReqPositionalWorkerPool(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalWorkerPool(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestReqPositionalWorkerPool.vm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalWorkerPool.vm(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestReqPositionalWorkerPool.js(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalWorkerPool.js(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestReqPositionalWorkerPool.wasm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalWorkerPool.wasm(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestReqPositionalWorkerPool _$pool;
+
+  static final Finalizer<_$TestReqPositionalWorkerPool> _finalizer =
+      Finalizer<_$TestReqPositionalWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestReqPositionalWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(TestReqPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(TestReqPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestReqPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestReqPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -267,10 +822,10 @@ sq.WorkerService $TestOptNullPositionalInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestOptNullPositional
-base class TestOptNullPositionalWorker extends sq.Worker
+base class _$TestOptNullPositionalWorker extends sq.Worker
     with _$TestOptNullPositional$Invoker, _$TestOptNullPositional$Facade
     implements TestOptNullPositional {
-  TestOptNullPositionalWorker(
+  _$TestOptNullPositionalWorker(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -278,7 +833,7 @@ base class TestOptNullPositionalWorker extends sq.Worker
         super($TestOptNullPositionalActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullPositionalWorker.vm(
+  _$TestOptNullPositionalWorker.vm(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -286,7 +841,7 @@ base class TestOptNullPositionalWorker extends sq.Worker
         super($TestOptNullPositionalActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullPositionalWorker.js(
+  _$TestOptNullPositionalWorker.js(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -294,7 +849,7 @@ base class TestOptNullPositionalWorker extends sq.Worker
         super($TestOptNullPositionalActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullPositionalWorker.wasm(
+  _$TestOptNullPositionalWorker.wasm(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -306,14 +861,144 @@ base class TestOptNullPositionalWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullPositional
+base class TestOptNullPositionalWorker
+    with Releasable
+    implements _$TestOptNullPositionalWorker {
+  TestOptNullPositionalWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullPositionalWorker(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(
+            _$TestOptNullPositionalWorker(arg1, threadHook, exceptionManager));
+
+  TestOptNullPositionalWorker.vm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullPositionalWorker.vm(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullPositionalWorker.js(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullPositionalWorker.js(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullPositionalWorker.wasm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullPositionalWorker.wasm(
+            arg1, threadHook, exceptionManager));
+
+  final _$TestOptNullPositionalWorker _$worker;
+
+  static final Finalizer<_$TestOptNullPositionalWorker> _finalizer =
+      Finalizer<_$TestOptNullPositionalWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullPositional
-base class TestOptNullPositionalWorkerPool
+base class _$TestOptNullPositionalWorkerPool
     extends sq.WorkerPool<TestOptNullPositionalWorker>
     with _$TestOptNullPositional$Facade
     implements TestOptNullPositional {
-  TestOptNullPositionalWorkerPool(
+  _$TestOptNullPositionalWorkerPool(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -324,7 +1009,7 @@ base class TestOptNullPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalWorkerPool.vm(
+  _$TestOptNullPositionalWorkerPool.vm(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -336,7 +1021,7 @@ base class TestOptNullPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalWorkerPool.js(
+  _$TestOptNullPositionalWorkerPool.js(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -348,7 +1033,7 @@ base class TestOptNullPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalWorkerPool.wasm(
+  _$TestOptNullPositionalWorkerPool.wasm(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -359,6 +1044,157 @@ base class TestOptNullPositionalWorkerPool
                     arg1, threadHook, exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullPositional
+base class TestOptNullPositionalWorkerPool
+    with Releasable
+    implements _$TestOptNullPositionalWorkerPool {
+  TestOptNullPositionalWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullPositionalWorkerPool(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalWorkerPool(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullPositionalWorkerPool.vm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalWorkerPool.vm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullPositionalWorkerPool.js(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalWorkerPool.js(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullPositionalWorkerPool.wasm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalWorkerPool.wasm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  final _$TestOptNullPositionalWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullPositionalWorkerPool> _finalizer =
+      Finalizer<_$TestOptNullPositionalWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestOptNullPositionalWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptNullPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptNullPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -393,10 +1229,10 @@ sq.WorkerService $TestOptDefPositionalInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestOptDefPositional
-base class TestOptDefPositionalWorker extends sq.Worker
+base class _$TestOptDefPositionalWorker extends sq.Worker
     with _$TestOptDefPositional$Invoker, _$TestOptDefPositional$Facade
     implements TestOptDefPositional {
-  TestOptDefPositionalWorker(
+  _$TestOptDefPositionalWorker(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -404,7 +1240,7 @@ base class TestOptDefPositionalWorker extends sq.Worker
         super($TestOptDefPositionalActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefPositionalWorker.vm(
+  _$TestOptDefPositionalWorker.vm(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -412,7 +1248,7 @@ base class TestOptDefPositionalWorker extends sq.Worker
         super($TestOptDefPositionalActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefPositionalWorker.js(
+  _$TestOptDefPositionalWorker.js(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -420,7 +1256,7 @@ base class TestOptDefPositionalWorker extends sq.Worker
         super($TestOptDefPositionalActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefPositionalWorker.wasm(
+  _$TestOptDefPositionalWorker.wasm(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -432,14 +1268,144 @@ base class TestOptDefPositionalWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptDefPositional
+base class TestOptDefPositionalWorker
+    with Releasable
+    implements _$TestOptDefPositionalWorker {
+  TestOptDefPositionalWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptDefPositionalWorker(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(
+            _$TestOptDefPositionalWorker(arg1, threadHook, exceptionManager));
+
+  TestOptDefPositionalWorker.vm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptDefPositionalWorker.vm(
+            arg1, threadHook, exceptionManager));
+
+  TestOptDefPositionalWorker.js(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptDefPositionalWorker.js(
+            arg1, threadHook, exceptionManager));
+
+  TestOptDefPositionalWorker.wasm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptDefPositionalWorker.wasm(
+            arg1, threadHook, exceptionManager));
+
+  final _$TestOptDefPositionalWorker _$worker;
+
+  static final Finalizer<_$TestOptDefPositionalWorker> _finalizer =
+      Finalizer<_$TestOptDefPositionalWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptDefPositional
-base class TestOptDefPositionalWorkerPool
+base class _$TestOptDefPositionalWorkerPool
     extends sq.WorkerPool<TestOptDefPositionalWorker>
     with _$TestOptDefPositional$Facade
     implements TestOptDefPositional {
-  TestOptDefPositionalWorkerPool(
+  _$TestOptDefPositionalWorkerPool(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -450,7 +1416,7 @@ base class TestOptDefPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalWorkerPool.vm(
+  _$TestOptDefPositionalWorkerPool.vm(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -462,7 +1428,7 @@ base class TestOptDefPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalWorkerPool.js(
+  _$TestOptDefPositionalWorkerPool.js(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -474,7 +1440,7 @@ base class TestOptDefPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalWorkerPool.wasm(
+  _$TestOptDefPositionalWorkerPool.wasm(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -485,6 +1451,157 @@ base class TestOptDefPositionalWorkerPool
                     arg1, threadHook, exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptDefPositional
+base class TestOptDefPositionalWorkerPool
+    with Releasable
+    implements _$TestOptDefPositionalWorkerPool {
+  TestOptDefPositionalWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptDefPositionalWorkerPool(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalWorkerPool(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptDefPositionalWorkerPool.vm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalWorkerPool.vm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptDefPositionalWorkerPool.js(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalWorkerPool.js(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptDefPositionalWorkerPool.wasm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalWorkerPool.wasm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  final _$TestOptDefPositionalWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptDefPositionalWorkerPool> _finalizer =
+      Finalizer<_$TestOptDefPositionalWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestOptDefPositionalWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptDefPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptDefPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptDefPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptDefPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -519,10 +1636,10 @@ sq.WorkerService $TestOptNullDefPositionalInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestOptNullDefPositional
-base class TestOptNullDefPositionalWorker extends sq.Worker
+base class _$TestOptNullDefPositionalWorker extends sq.Worker
     with _$TestOptNullDefPositional$Invoker, _$TestOptNullDefPositional$Facade
     implements TestOptNullDefPositional {
-  TestOptNullDefPositionalWorker(
+  _$TestOptNullDefPositionalWorker(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -530,7 +1647,7 @@ base class TestOptNullDefPositionalWorker extends sq.Worker
         super($TestOptNullDefPositionalActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalWorker.vm(
+  _$TestOptNullDefPositionalWorker.vm(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -538,7 +1655,7 @@ base class TestOptNullDefPositionalWorker extends sq.Worker
         super($TestOptNullDefPositionalActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalWorker.js(
+  _$TestOptNullDefPositionalWorker.js(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -546,7 +1663,7 @@ base class TestOptNullDefPositionalWorker extends sq.Worker
         super($TestOptNullDefPositionalActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalWorker.wasm(
+  _$TestOptNullDefPositionalWorker.wasm(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -558,14 +1675,144 @@ base class TestOptNullDefPositionalWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullDefPositional
+base class TestOptNullDefPositionalWorker
+    with Releasable
+    implements _$TestOptNullDefPositionalWorker {
+  TestOptNullDefPositionalWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullDefPositionalWorker(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalWorker(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullDefPositionalWorker.vm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalWorker.vm(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullDefPositionalWorker.js(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalWorker.js(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullDefPositionalWorker.wasm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalWorker.wasm(
+            arg1, threadHook, exceptionManager));
+
+  final _$TestOptNullDefPositionalWorker _$worker;
+
+  static final Finalizer<_$TestOptNullDefPositionalWorker> _finalizer =
+      Finalizer<_$TestOptNullDefPositionalWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullDefPositional
-base class TestOptNullDefPositionalWorkerPool
+base class _$TestOptNullDefPositionalWorkerPool
     extends sq.WorkerPool<TestOptNullDefPositionalWorker>
     with _$TestOptNullDefPositional$Facade
     implements TestOptNullDefPositional {
-  TestOptNullDefPositionalWorkerPool(
+  _$TestOptNullDefPositionalWorkerPool(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -577,7 +1824,7 @@ base class TestOptNullDefPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalWorkerPool.vm(
+  _$TestOptNullDefPositionalWorkerPool.vm(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -589,7 +1836,7 @@ base class TestOptNullDefPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalWorkerPool.js(
+  _$TestOptNullDefPositionalWorkerPool.js(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -601,7 +1848,7 @@ base class TestOptNullDefPositionalWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalWorkerPool.wasm(
+  _$TestOptNullDefPositionalWorkerPool.wasm(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -612,6 +1859,157 @@ base class TestOptNullDefPositionalWorkerPool
                     arg1, threadHook, exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullDefPositional
+base class TestOptNullDefPositionalWorkerPool
+    with Releasable
+    implements _$TestOptNullDefPositionalWorkerPool {
+  TestOptNullDefPositionalWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullDefPositionalWorkerPool(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalWorkerPool(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullDefPositionalWorkerPool.vm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalWorkerPool.vm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullDefPositionalWorkerPool.js(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalWorkerPool.js(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullDefPositionalWorkerPool.wasm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalWorkerPool.wasm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  final _$TestOptNullDefPositionalWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullDefPositionalWorkerPool> _finalizer =
+      Finalizer<_$TestOptNullDefPositionalWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestOptNullDefPositionalWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptNullDefPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptNullDefPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullDefPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullDefPositionalWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -646,31 +2044,31 @@ sq.WorkerService $TestReqPositionalFieldInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestReqPositionalField
-base class TestReqPositionalFieldWorker extends sq.Worker
+base class _$TestReqPositionalFieldWorker extends sq.Worker
     with _$TestReqPositionalField$Invoker, _$TestReqPositionalField$Facade
     implements TestReqPositionalField {
-  TestReqPositionalFieldWorker(this.arg1,
+  _$TestReqPositionalFieldWorker(this.arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
         super($TestReqPositionalFieldActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestReqPositionalFieldWorker.vm(this.arg1,
+  _$TestReqPositionalFieldWorker.vm(this.arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
         super($TestReqPositionalFieldActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestReqPositionalFieldWorker.js(this.arg1,
+  _$TestReqPositionalFieldWorker.js(this.arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
         super($TestReqPositionalFieldActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestReqPositionalFieldWorker.wasm(this.arg1,
+  _$TestReqPositionalFieldWorker.wasm(this.arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
@@ -684,14 +2082,143 @@ base class TestReqPositionalFieldWorker extends sq.Worker
 
   @override
   final int arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestReqPositionalField
+base class TestReqPositionalFieldWorker
+    with Releasable
+    implements _$TestReqPositionalFieldWorker {
+  TestReqPositionalFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestReqPositionalFieldWorker(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalFieldWorker(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestReqPositionalFieldWorker.vm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalFieldWorker.vm(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestReqPositionalFieldWorker.js(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalFieldWorker.js(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestReqPositionalFieldWorker.wasm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalFieldWorker.wasm(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  @override
+  int get arg1 => _$worker.arg1;
+
+  final _$TestReqPositionalFieldWorker _$worker;
+
+  static final Finalizer<_$TestReqPositionalFieldWorker> _finalizer =
+      Finalizer<_$TestReqPositionalFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestReqPositionalField
-base class TestReqPositionalFieldWorkerPool
+base class _$TestReqPositionalFieldWorkerPool
     extends sq.WorkerPool<TestReqPositionalFieldWorker>
     with _$TestReqPositionalField$Facade
     implements TestReqPositionalField {
-  TestReqPositionalFieldWorkerPool(this.arg1,
+  _$TestReqPositionalFieldWorkerPool(this.arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -702,7 +2229,7 @@ base class TestReqPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestReqPositionalFieldWorkerPool.vm(this.arg1,
+  _$TestReqPositionalFieldWorkerPool.vm(this.arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -713,7 +2240,7 @@ base class TestReqPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestReqPositionalFieldWorkerPool.js(this.arg1,
+  _$TestReqPositionalFieldWorkerPool.js(this.arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -724,7 +2251,7 @@ base class TestReqPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestReqPositionalFieldWorkerPool.wasm(this.arg1,
+  _$TestReqPositionalFieldWorkerPool.wasm(this.arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -737,6 +2264,164 @@ base class TestReqPositionalFieldWorkerPool
 
   @override
   final int arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestReqPositionalField
+base class TestReqPositionalFieldWorkerPool
+    with Releasable
+    implements _$TestReqPositionalFieldWorkerPool {
+  TestReqPositionalFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestReqPositionalFieldWorkerPool(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalFieldWorkerPool(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestReqPositionalFieldWorkerPool.vm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalFieldWorkerPool.vm(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestReqPositionalFieldWorkerPool.js(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalFieldWorkerPool.js(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestReqPositionalFieldWorkerPool.wasm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalFieldWorkerPool.wasm(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  @override
+  int get arg1 => _$pool.arg1;
+
+  final _$TestReqPositionalFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestReqPositionalFieldWorkerPool> _finalizer =
+      Finalizer<_$TestReqPositionalFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestReqPositionalFieldWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestReqPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestReqPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestReqPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestReqPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -772,12 +2457,12 @@ sq.WorkerService $TestOptNullPositionalFieldInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestOptNullPositionalField
-base class TestOptNullPositionalFieldWorker extends sq.Worker
+base class _$TestOptNullPositionalFieldWorker extends sq.Worker
     with
         _$TestOptNullPositionalField$Invoker,
         _$TestOptNullPositionalField$Facade
     implements TestOptNullPositionalField {
-  TestOptNullPositionalFieldWorker(
+  _$TestOptNullPositionalFieldWorker(
       [this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -785,7 +2470,7 @@ base class TestOptNullPositionalFieldWorker extends sq.Worker
         super($TestOptNullPositionalFieldActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullPositionalFieldWorker.vm(
+  _$TestOptNullPositionalFieldWorker.vm(
       [this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -793,7 +2478,7 @@ base class TestOptNullPositionalFieldWorker extends sq.Worker
         super($TestOptNullPositionalFieldActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullPositionalFieldWorker.js(
+  _$TestOptNullPositionalFieldWorker.js(
       [this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -801,7 +2486,7 @@ base class TestOptNullPositionalFieldWorker extends sq.Worker
         super($TestOptNullPositionalFieldActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullPositionalFieldWorker.wasm(
+  _$TestOptNullPositionalFieldWorker.wasm(
       [this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -818,14 +2503,147 @@ base class TestOptNullPositionalFieldWorker extends sq.Worker
 
   @override
   final int? arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullPositionalField
+base class TestOptNullPositionalFieldWorker
+    with Releasable
+    implements _$TestOptNullPositionalFieldWorker {
+  TestOptNullPositionalFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullPositionalFieldWorker(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullPositionalFieldWorker(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullPositionalFieldWorker.vm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullPositionalFieldWorker.vm(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullPositionalFieldWorker.js(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullPositionalFieldWorker.js(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullPositionalFieldWorker.wasm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullPositionalFieldWorker.wasm(
+            arg1, threadHook, exceptionManager));
+
+  @override
+  int? get arg1 => _$worker.arg1;
+
+  final _$TestOptNullPositionalFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptNullPositionalFieldWorker> _finalizer =
+      Finalizer<_$TestOptNullPositionalFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullPositionalField
-base class TestOptNullPositionalFieldWorkerPool
+base class _$TestOptNullPositionalFieldWorkerPool
     extends sq.WorkerPool<TestOptNullPositionalFieldWorker>
     with _$TestOptNullPositionalField$Facade
     implements TestOptNullPositionalField {
-  TestOptNullPositionalFieldWorkerPool(
+  _$TestOptNullPositionalFieldWorkerPool(
       [this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -837,7 +2655,7 @@ base class TestOptNullPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalFieldWorkerPool.vm(
+  _$TestOptNullPositionalFieldWorkerPool.vm(
       [this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -849,7 +2667,7 @@ base class TestOptNullPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalFieldWorkerPool.js(
+  _$TestOptNullPositionalFieldWorkerPool.js(
       [this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -861,7 +2679,7 @@ base class TestOptNullPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalFieldWorkerPool.wasm(
+  _$TestOptNullPositionalFieldWorkerPool.wasm(
       [this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -875,6 +2693,162 @@ base class TestOptNullPositionalFieldWorkerPool
 
   @override
   final int? arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullPositionalField
+base class TestOptNullPositionalFieldWorkerPool
+    with Releasable
+    implements _$TestOptNullPositionalFieldWorkerPool {
+  TestOptNullPositionalFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullPositionalFieldWorkerPool(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalFieldWorkerPool(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullPositionalFieldWorkerPool.vm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalFieldWorkerPool.vm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullPositionalFieldWorkerPool.js(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalFieldWorkerPool.js(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullPositionalFieldWorkerPool.wasm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalFieldWorkerPool.wasm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  @override
+  int? get arg1 => _$pool.arg1;
+
+  final _$TestOptNullPositionalFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullPositionalFieldWorkerPool> _finalizer =
+      Finalizer<_$TestOptNullPositionalFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop(
+          [bool Function(TestOptNullPositionalFieldWorker worker)?
+              predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptNullPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptNullPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -909,10 +2883,10 @@ sq.WorkerService $TestOptDefPositionalFieldInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestOptDefPositionalField
-base class TestOptDefPositionalFieldWorker extends sq.Worker
+base class _$TestOptDefPositionalFieldWorker extends sq.Worker
     with _$TestOptDefPositionalField$Invoker, _$TestOptDefPositionalField$Facade
     implements TestOptDefPositionalField {
-  TestOptDefPositionalFieldWorker(
+  _$TestOptDefPositionalFieldWorker(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -920,7 +2894,7 @@ base class TestOptDefPositionalFieldWorker extends sq.Worker
         super($TestOptDefPositionalFieldActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefPositionalFieldWorker.vm(
+  _$TestOptDefPositionalFieldWorker.vm(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -928,7 +2902,7 @@ base class TestOptDefPositionalFieldWorker extends sq.Worker
         super($TestOptDefPositionalFieldActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefPositionalFieldWorker.js(
+  _$TestOptDefPositionalFieldWorker.js(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -936,7 +2910,7 @@ base class TestOptDefPositionalFieldWorker extends sq.Worker
         super($TestOptDefPositionalFieldActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefPositionalFieldWorker.wasm(
+  _$TestOptDefPositionalFieldWorker.wasm(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -951,14 +2925,147 @@ base class TestOptDefPositionalFieldWorker extends sq.Worker
 
   @override
   final int arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptDefPositionalField
+base class TestOptDefPositionalFieldWorker
+    with Releasable
+    implements _$TestOptDefPositionalFieldWorker {
+  TestOptDefPositionalFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptDefPositionalFieldWorker(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptDefPositionalFieldWorker(
+            arg1, threadHook, exceptionManager));
+
+  TestOptDefPositionalFieldWorker.vm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptDefPositionalFieldWorker.vm(
+            arg1, threadHook, exceptionManager));
+
+  TestOptDefPositionalFieldWorker.js(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptDefPositionalFieldWorker.js(
+            arg1, threadHook, exceptionManager));
+
+  TestOptDefPositionalFieldWorker.wasm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptDefPositionalFieldWorker.wasm(
+            arg1, threadHook, exceptionManager));
+
+  @override
+  int get arg1 => _$worker.arg1;
+
+  final _$TestOptDefPositionalFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptDefPositionalFieldWorker> _finalizer =
+      Finalizer<_$TestOptDefPositionalFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptDefPositionalField
-base class TestOptDefPositionalFieldWorkerPool
+base class _$TestOptDefPositionalFieldWorkerPool
     extends sq.WorkerPool<TestOptDefPositionalFieldWorker>
     with _$TestOptDefPositionalField$Facade
     implements TestOptDefPositionalField {
-  TestOptDefPositionalFieldWorkerPool(
+  _$TestOptDefPositionalFieldWorkerPool(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -970,7 +3077,7 @@ base class TestOptDefPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalFieldWorkerPool.vm(
+  _$TestOptDefPositionalFieldWorkerPool.vm(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -982,7 +3089,7 @@ base class TestOptDefPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalFieldWorkerPool.js(
+  _$TestOptDefPositionalFieldWorkerPool.js(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -994,7 +3101,7 @@ base class TestOptDefPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalFieldWorkerPool.wasm(
+  _$TestOptDefPositionalFieldWorkerPool.wasm(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1008,6 +3115,161 @@ base class TestOptDefPositionalFieldWorkerPool
 
   @override
   final int arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptDefPositionalField
+base class TestOptDefPositionalFieldWorkerPool
+    with Releasable
+    implements _$TestOptDefPositionalFieldWorkerPool {
+  TestOptDefPositionalFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptDefPositionalFieldWorkerPool(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalFieldWorkerPool(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptDefPositionalFieldWorkerPool.vm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalFieldWorkerPool.vm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptDefPositionalFieldWorkerPool.js(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalFieldWorkerPool.js(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptDefPositionalFieldWorkerPool.wasm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalFieldWorkerPool.wasm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  @override
+  int get arg1 => _$pool.arg1;
+
+  final _$TestOptDefPositionalFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptDefPositionalFieldWorkerPool> _finalizer =
+      Finalizer<_$TestOptDefPositionalFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop(
+          [bool Function(TestOptDefPositionalFieldWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptDefPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptDefPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptDefPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptDefPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -1044,12 +3306,12 @@ sq.WorkerService $TestOptNullDefPositionalFieldInitializer(
 }
 
 /// Worker for TestOptNullDefPositionalField
-base class TestOptNullDefPositionalFieldWorker extends sq.Worker
+base class _$TestOptNullDefPositionalFieldWorker extends sq.Worker
     with
         _$TestOptNullDefPositionalField$Invoker,
         _$TestOptNullDefPositionalField$Facade
     implements TestOptNullDefPositionalField {
-  TestOptNullDefPositionalFieldWorker(
+  _$TestOptNullDefPositionalFieldWorker(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1057,7 +3319,7 @@ base class TestOptNullDefPositionalFieldWorker extends sq.Worker
         super($TestOptNullDefPositionalFieldActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalFieldWorker.vm(
+  _$TestOptNullDefPositionalFieldWorker.vm(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1067,7 +3329,7 @@ base class TestOptNullDefPositionalFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalFieldWorker.js(
+  _$TestOptNullDefPositionalFieldWorker.js(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1077,7 +3339,7 @@ base class TestOptNullDefPositionalFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalFieldWorker.wasm(
+  _$TestOptNullDefPositionalFieldWorker.wasm(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1095,14 +3357,147 @@ base class TestOptNullDefPositionalFieldWorker extends sq.Worker
 
   @override
   final int? arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullDefPositionalField
+base class TestOptNullDefPositionalFieldWorker
+    with Releasable
+    implements _$TestOptNullDefPositionalFieldWorker {
+  TestOptNullDefPositionalFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullDefPositionalFieldWorker(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalFieldWorker(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullDefPositionalFieldWorker.vm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalFieldWorker.vm(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullDefPositionalFieldWorker.js(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalFieldWorker.js(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullDefPositionalFieldWorker.wasm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalFieldWorker.wasm(
+            arg1, threadHook, exceptionManager));
+
+  @override
+  int? get arg1 => _$worker.arg1;
+
+  final _$TestOptNullDefPositionalFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptNullDefPositionalFieldWorker> _finalizer =
+      Finalizer<_$TestOptNullDefPositionalFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullDefPositionalField
-base class TestOptNullDefPositionalFieldWorkerPool
+base class _$TestOptNullDefPositionalFieldWorkerPool
     extends sq.WorkerPool<TestOptNullDefPositionalFieldWorker>
     with _$TestOptNullDefPositionalField$Facade
     implements TestOptNullDefPositionalField {
-  TestOptNullDefPositionalFieldWorkerPool(
+  _$TestOptNullDefPositionalFieldWorkerPool(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1114,7 +3509,7 @@ base class TestOptNullDefPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalFieldWorkerPool.vm(
+  _$TestOptNullDefPositionalFieldWorkerPool.vm(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1126,7 +3521,7 @@ base class TestOptNullDefPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalFieldWorkerPool.js(
+  _$TestOptNullDefPositionalFieldWorkerPool.js(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1138,7 +3533,7 @@ base class TestOptNullDefPositionalFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalFieldWorkerPool.wasm(
+  _$TestOptNullDefPositionalFieldWorkerPool.wasm(
       [this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1152,6 +3547,162 @@ base class TestOptNullDefPositionalFieldWorkerPool
 
   @override
   final int? arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullDefPositionalField
+base class TestOptNullDefPositionalFieldWorkerPool
+    with Releasable
+    implements _$TestOptNullDefPositionalFieldWorkerPool {
+  TestOptNullDefPositionalFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullDefPositionalFieldWorkerPool(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalFieldWorkerPool(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullDefPositionalFieldWorkerPool.vm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalFieldWorkerPool.vm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullDefPositionalFieldWorkerPool.js(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalFieldWorkerPool.js(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullDefPositionalFieldWorkerPool.wasm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalFieldWorkerPool.wasm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  @override
+  int? get arg1 => _$pool.arg1;
+
+  final _$TestOptNullDefPositionalFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullDefPositionalFieldWorkerPool> _finalizer =
+      Finalizer<_$TestOptNullDefPositionalFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop(
+          [bool Function(TestOptNullDefPositionalFieldWorker worker)?
+              predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptNullDefPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptNullDefPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullDefPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullDefPositionalFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -1192,19 +3743,19 @@ sq.WorkerService $TestReqPositionalPrivateFieldInitializer(
 }
 
 /// Worker for TestReqPositionalPrivateField
-base class TestReqPositionalPrivateFieldWorker extends sq.Worker
+base class _$TestReqPositionalPrivateFieldWorker extends sq.Worker
     with
         _$TestReqPositionalPrivateField$Invoker,
         _$TestReqPositionalPrivateField$Facade
     implements TestReqPositionalPrivateField {
-  TestReqPositionalPrivateFieldWorker(int arg1,
+  _$TestReqPositionalPrivateFieldWorker(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
         super($TestReqPositionalPrivateFieldActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestReqPositionalPrivateFieldWorker.vm(int arg1,
+  _$TestReqPositionalPrivateFieldWorker.vm(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
@@ -1213,7 +3764,7 @@ base class TestReqPositionalPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestReqPositionalPrivateFieldWorker.js(int arg1,
+  _$TestReqPositionalPrivateFieldWorker.js(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
@@ -1222,7 +3773,7 @@ base class TestReqPositionalPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestReqPositionalPrivateFieldWorker.wasm(int arg1,
+  _$TestReqPositionalPrivateFieldWorker.wasm(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [arg1],
@@ -1236,14 +3787,143 @@ base class TestReqPositionalPrivateFieldWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestReqPositionalPrivateField
+base class TestReqPositionalPrivateFieldWorker
+    with Releasable
+    implements _$TestReqPositionalPrivateFieldWorker {
+  TestReqPositionalPrivateFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestReqPositionalPrivateFieldWorker(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalPrivateFieldWorker(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestReqPositionalPrivateFieldWorker.vm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalPrivateFieldWorker.vm(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestReqPositionalPrivateFieldWorker.js(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalPrivateFieldWorker.js(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestReqPositionalPrivateFieldWorker.wasm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestReqPositionalPrivateFieldWorker.wasm(arg1,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$TestReqPositionalPrivateFieldWorker _$worker;
+
+  static final Finalizer<_$TestReqPositionalPrivateFieldWorker> _finalizer =
+      Finalizer<_$TestReqPositionalPrivateFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  int get _arg1 => _$worker._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestReqPositionalPrivateField
-base class TestReqPositionalPrivateFieldWorkerPool
+base class _$TestReqPositionalPrivateFieldWorkerPool
     extends sq.WorkerPool<TestReqPositionalPrivateFieldWorker>
     with _$TestReqPositionalPrivateField$Facade
     implements TestReqPositionalPrivateField {
-  TestReqPositionalPrivateFieldWorkerPool(int arg1,
+  _$TestReqPositionalPrivateFieldWorkerPool(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -1254,7 +3934,7 @@ base class TestReqPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestReqPositionalPrivateFieldWorkerPool.vm(int arg1,
+  _$TestReqPositionalPrivateFieldWorkerPool.vm(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -1265,7 +3945,7 @@ base class TestReqPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestReqPositionalPrivateFieldWorkerPool.js(int arg1,
+  _$TestReqPositionalPrivateFieldWorkerPool.js(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -1276,7 +3956,7 @@ base class TestReqPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestReqPositionalPrivateFieldWorkerPool.wasm(int arg1,
+  _$TestReqPositionalPrivateFieldWorkerPool.wasm(int arg1,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -1286,6 +3966,166 @@ base class TestReqPositionalPrivateFieldWorkerPool
                     threadHook: threadHook, exceptionManager: exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestReqPositionalPrivateField
+base class TestReqPositionalPrivateFieldWorkerPool
+    with Releasable
+    implements _$TestReqPositionalPrivateFieldWorkerPool {
+  TestReqPositionalPrivateFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestReqPositionalPrivateFieldWorkerPool(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalPrivateFieldWorkerPool(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestReqPositionalPrivateFieldWorkerPool.vm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalPrivateFieldWorkerPool.vm(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestReqPositionalPrivateFieldWorkerPool.js(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalPrivateFieldWorkerPool.js(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestReqPositionalPrivateFieldWorkerPool.wasm(int arg1,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestReqPositionalPrivateFieldWorkerPool.wasm(arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestReqPositionalPrivateFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestReqPositionalPrivateFieldWorkerPool> _finalizer =
+      Finalizer<_$TestReqPositionalPrivateFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  int get _arg1 => _$pool._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop(
+          [bool Function(TestReqPositionalPrivateFieldWorker worker)?
+              predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestReqPositionalPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestReqPositionalPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestReqPositionalPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestReqPositionalPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -1327,12 +4167,12 @@ sq.WorkerService $TestOptNullPositionalPrivateFieldInitializer(
 }
 
 /// Worker for TestOptNullPositionalPrivateField
-base class TestOptNullPositionalPrivateFieldWorker extends sq.Worker
+base class _$TestOptNullPositionalPrivateFieldWorker extends sq.Worker
     with
         _$TestOptNullPositionalPrivateField$Invoker,
         _$TestOptNullPositionalPrivateField$Facade
     implements TestOptNullPositionalPrivateField {
-  TestOptNullPositionalPrivateFieldWorker(
+  _$TestOptNullPositionalPrivateFieldWorker(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1343,7 +4183,7 @@ base class TestOptNullPositionalPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalPrivateFieldWorker.vm(
+  _$TestOptNullPositionalPrivateFieldWorker.vm(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1354,7 +4194,7 @@ base class TestOptNullPositionalPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalPrivateFieldWorker.js(
+  _$TestOptNullPositionalPrivateFieldWorker.js(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1365,7 +4205,7 @@ base class TestOptNullPositionalPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalPrivateFieldWorker.wasm(
+  _$TestOptNullPositionalPrivateFieldWorker.wasm(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1380,14 +4220,147 @@ base class TestOptNullPositionalPrivateFieldWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullPositionalPrivateField
+base class TestOptNullPositionalPrivateFieldWorker
+    with Releasable
+    implements _$TestOptNullPositionalPrivateFieldWorker {
+  TestOptNullPositionalPrivateFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullPositionalPrivateFieldWorker(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullPositionalPrivateFieldWorker(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullPositionalPrivateFieldWorker.vm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullPositionalPrivateFieldWorker.vm(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullPositionalPrivateFieldWorker.js(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullPositionalPrivateFieldWorker.js(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullPositionalPrivateFieldWorker.wasm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullPositionalPrivateFieldWorker.wasm(
+            arg1, threadHook, exceptionManager));
+
+  final _$TestOptNullPositionalPrivateFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptNullPositionalPrivateFieldWorker> _finalizer =
+      Finalizer<_$TestOptNullPositionalPrivateFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  int? get _arg1 => _$worker._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullPositionalPrivateField
-base class TestOptNullPositionalPrivateFieldWorkerPool
+base class _$TestOptNullPositionalPrivateFieldWorkerPool
     extends sq.WorkerPool<TestOptNullPositionalPrivateFieldWorker>
     with _$TestOptNullPositionalPrivateField$Facade
     implements TestOptNullPositionalPrivateField {
-  TestOptNullPositionalPrivateFieldWorkerPool(
+  _$TestOptNullPositionalPrivateFieldWorkerPool(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1399,7 +4372,7 @@ base class TestOptNullPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalPrivateFieldWorkerPool.vm(
+  _$TestOptNullPositionalPrivateFieldWorkerPool.vm(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1411,7 +4384,7 @@ base class TestOptNullPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalPrivateFieldWorkerPool.js(
+  _$TestOptNullPositionalPrivateFieldWorkerPool.js(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1423,7 +4396,7 @@ base class TestOptNullPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullPositionalPrivateFieldWorkerPool.wasm(
+  _$TestOptNullPositionalPrivateFieldWorkerPool.wasm(
       [int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1434,6 +4407,167 @@ base class TestOptNullPositionalPrivateFieldWorkerPool
                     arg1, threadHook, exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullPositionalPrivateField
+base class TestOptNullPositionalPrivateFieldWorkerPool
+    with Releasable
+    implements _$TestOptNullPositionalPrivateFieldWorkerPool {
+  TestOptNullPositionalPrivateFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullPositionalPrivateFieldWorkerPool(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalPrivateFieldWorkerPool(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullPositionalPrivateFieldWorkerPool.vm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalPrivateFieldWorkerPool.vm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullPositionalPrivateFieldWorkerPool.js(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalPrivateFieldWorkerPool.js(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullPositionalPrivateFieldWorkerPool.wasm(
+      [int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullPositionalPrivateFieldWorkerPool.wasm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  final _$TestOptNullPositionalPrivateFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullPositionalPrivateFieldWorkerPool>
+      _finalizer =
+      Finalizer<_$TestOptNullPositionalPrivateFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  int? get _arg1 => _$pool._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop(
+          [bool Function(TestOptNullPositionalPrivateFieldWorker worker)?
+              predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptNullPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptNullPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -1475,12 +4609,12 @@ sq.WorkerService $TestOptDefPositionalPrivateFieldInitializer(
 }
 
 /// Worker for TestOptDefPositionalPrivateField
-base class TestOptDefPositionalPrivateFieldWorker extends sq.Worker
+base class _$TestOptDefPositionalPrivateFieldWorker extends sq.Worker
     with
         _$TestOptDefPositionalPrivateField$Invoker,
         _$TestOptDefPositionalPrivateField$Facade
     implements TestOptDefPositionalPrivateField {
-  TestOptDefPositionalPrivateFieldWorker(
+  _$TestOptDefPositionalPrivateFieldWorker(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1491,7 +4625,7 @@ base class TestOptDefPositionalPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalPrivateFieldWorker.vm(
+  _$TestOptDefPositionalPrivateFieldWorker.vm(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1502,7 +4636,7 @@ base class TestOptDefPositionalPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalPrivateFieldWorker.js(
+  _$TestOptDefPositionalPrivateFieldWorker.js(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1513,7 +4647,7 @@ base class TestOptDefPositionalPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalPrivateFieldWorker.wasm(
+  _$TestOptDefPositionalPrivateFieldWorker.wasm(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1528,14 +4662,147 @@ base class TestOptDefPositionalPrivateFieldWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptDefPositionalPrivateField
+base class TestOptDefPositionalPrivateFieldWorker
+    with Releasable
+    implements _$TestOptDefPositionalPrivateFieldWorker {
+  TestOptDefPositionalPrivateFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptDefPositionalPrivateFieldWorker(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptDefPositionalPrivateFieldWorker(
+            arg1, threadHook, exceptionManager));
+
+  TestOptDefPositionalPrivateFieldWorker.vm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptDefPositionalPrivateFieldWorker.vm(
+            arg1, threadHook, exceptionManager));
+
+  TestOptDefPositionalPrivateFieldWorker.js(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptDefPositionalPrivateFieldWorker.js(
+            arg1, threadHook, exceptionManager));
+
+  TestOptDefPositionalPrivateFieldWorker.wasm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptDefPositionalPrivateFieldWorker.wasm(
+            arg1, threadHook, exceptionManager));
+
+  final _$TestOptDefPositionalPrivateFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptDefPositionalPrivateFieldWorker> _finalizer =
+      Finalizer<_$TestOptDefPositionalPrivateFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  int get _arg1 => _$worker._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptDefPositionalPrivateField
-base class TestOptDefPositionalPrivateFieldWorkerPool
+base class _$TestOptDefPositionalPrivateFieldWorkerPool
     extends sq.WorkerPool<TestOptDefPositionalPrivateFieldWorker>
     with _$TestOptDefPositionalPrivateField$Facade
     implements TestOptDefPositionalPrivateField {
-  TestOptDefPositionalPrivateFieldWorkerPool(
+  _$TestOptDefPositionalPrivateFieldWorkerPool(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1547,7 +4814,7 @@ base class TestOptDefPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalPrivateFieldWorkerPool.vm(
+  _$TestOptDefPositionalPrivateFieldWorkerPool.vm(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1559,7 +4826,7 @@ base class TestOptDefPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalPrivateFieldWorkerPool.js(
+  _$TestOptDefPositionalPrivateFieldWorkerPool.js(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1571,7 +4838,7 @@ base class TestOptDefPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefPositionalPrivateFieldWorkerPool.wasm(
+  _$TestOptDefPositionalPrivateFieldWorkerPool.wasm(
       [int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1582,6 +4849,166 @@ base class TestOptDefPositionalPrivateFieldWorkerPool
                     arg1, threadHook, exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptDefPositionalPrivateField
+base class TestOptDefPositionalPrivateFieldWorkerPool
+    with Releasable
+    implements _$TestOptDefPositionalPrivateFieldWorkerPool {
+  TestOptDefPositionalPrivateFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptDefPositionalPrivateFieldWorkerPool(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalPrivateFieldWorkerPool(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptDefPositionalPrivateFieldWorkerPool.vm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalPrivateFieldWorkerPool.vm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptDefPositionalPrivateFieldWorkerPool.js(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalPrivateFieldWorkerPool.js(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptDefPositionalPrivateFieldWorkerPool.wasm(
+      [int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptDefPositionalPrivateFieldWorkerPool.wasm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  final _$TestOptDefPositionalPrivateFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptDefPositionalPrivateFieldWorkerPool>
+      _finalizer = Finalizer<_$TestOptDefPositionalPrivateFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  int get _arg1 => _$pool._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop(
+          [bool Function(TestOptDefPositionalPrivateFieldWorker worker)?
+              predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptDefPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptDefPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptDefPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptDefPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -1624,12 +5051,12 @@ sq.WorkerService $TestOptNullDefPositionalPrivateFieldInitializer(
 }
 
 /// Worker for TestOptNullDefPositionalPrivateField
-base class TestOptNullDefPositionalPrivateFieldWorker extends sq.Worker
+base class _$TestOptNullDefPositionalPrivateFieldWorker extends sq.Worker
     with
         _$TestOptNullDefPositionalPrivateField$Invoker,
         _$TestOptNullDefPositionalPrivateField$Facade
     implements TestOptNullDefPositionalPrivateField {
-  TestOptNullDefPositionalPrivateFieldWorker(
+  _$TestOptNullDefPositionalPrivateFieldWorker(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1640,7 +5067,7 @@ base class TestOptNullDefPositionalPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalPrivateFieldWorker.vm(
+  _$TestOptNullDefPositionalPrivateFieldWorker.vm(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1651,7 +5078,7 @@ base class TestOptNullDefPositionalPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalPrivateFieldWorker.js(
+  _$TestOptNullDefPositionalPrivateFieldWorker.js(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1662,7 +5089,7 @@ base class TestOptNullDefPositionalPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalPrivateFieldWorker.wasm(
+  _$TestOptNullDefPositionalPrivateFieldWorker.wasm(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager])
@@ -1677,14 +5104,147 @@ base class TestOptNullDefPositionalPrivateFieldWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullDefPositionalPrivateField
+base class TestOptNullDefPositionalPrivateFieldWorker
+    with Releasable
+    implements _$TestOptNullDefPositionalPrivateFieldWorker {
+  TestOptNullDefPositionalPrivateFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullDefPositionalPrivateFieldWorker(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalPrivateFieldWorker(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullDefPositionalPrivateFieldWorker.vm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalPrivateFieldWorker.vm(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullDefPositionalPrivateFieldWorker.js(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalPrivateFieldWorker.js(
+            arg1, threadHook, exceptionManager));
+
+  TestOptNullDefPositionalPrivateFieldWorker.wasm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager])
+      : this._(_$TestOptNullDefPositionalPrivateFieldWorker.wasm(
+            arg1, threadHook, exceptionManager));
+
+  final _$TestOptNullDefPositionalPrivateFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptNullDefPositionalPrivateFieldWorker>
+      _finalizer = Finalizer<_$TestOptNullDefPositionalPrivateFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  int? get _arg1 => _$worker._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullDefPositionalPrivateField
-base class TestOptNullDefPositionalPrivateFieldWorkerPool
+base class _$TestOptNullDefPositionalPrivateFieldWorkerPool
     extends sq.WorkerPool<TestOptNullDefPositionalPrivateFieldWorker>
     with _$TestOptNullDefPositionalPrivateField$Facade
     implements TestOptNullDefPositionalPrivateField {
-  TestOptNullDefPositionalPrivateFieldWorkerPool(
+  _$TestOptNullDefPositionalPrivateFieldWorkerPool(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1696,7 +5256,7 @@ base class TestOptNullDefPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalPrivateFieldWorkerPool.vm(
+  _$TestOptNullDefPositionalPrivateFieldWorkerPool.vm(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1708,7 +5268,7 @@ base class TestOptNullDefPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalPrivateFieldWorkerPool.js(
+  _$TestOptNullDefPositionalPrivateFieldWorkerPool.js(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1720,7 +5280,7 @@ base class TestOptNullDefPositionalPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefPositionalPrivateFieldWorkerPool.wasm(
+  _$TestOptNullDefPositionalPrivateFieldWorkerPool.wasm(
       [int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1731,6 +5291,167 @@ base class TestOptNullDefPositionalPrivateFieldWorkerPool
                     arg1, threadHook, exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullDefPositionalPrivateField
+base class TestOptNullDefPositionalPrivateFieldWorkerPool
+    with Releasable
+    implements _$TestOptNullDefPositionalPrivateFieldWorkerPool {
+  TestOptNullDefPositionalPrivateFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullDefPositionalPrivateFieldWorkerPool(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalPrivateFieldWorkerPool(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullDefPositionalPrivateFieldWorkerPool.vm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalPrivateFieldWorkerPool.vm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullDefPositionalPrivateFieldWorkerPool.js(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalPrivateFieldWorkerPool.js(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  TestOptNullDefPositionalPrivateFieldWorkerPool.wasm(
+      [int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings])
+      : this._(_$TestOptNullDefPositionalPrivateFieldWorkerPool.wasm(
+            arg1, threadHook, exceptionManager, concurrencySettings));
+
+  final _$TestOptNullDefPositionalPrivateFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullDefPositionalPrivateFieldWorkerPool>
+      _finalizer =
+      Finalizer<_$TestOptNullDefPositionalPrivateFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  int? get _arg1 => _$pool._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop(
+          [bool Function(TestOptNullDefPositionalPrivateFieldWorker worker)?
+              predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptNullDefPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptNullDefPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullDefPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullDefPositionalPrivateFieldWorker worker)
+              task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -1764,10 +5485,10 @@ sq.WorkerService $TestOptNullNamedInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestOptNullNamed
-base class TestOptNullNamedWorker extends sq.Worker
+base class _$TestOptNullNamedWorker extends sq.Worker
     with _$TestOptNullNamed$Invoker, _$TestOptNullNamed$Facade
     implements TestOptNullNamed {
-  TestOptNullNamedWorker(
+  _$TestOptNullNamedWorker(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -1775,7 +5496,7 @@ base class TestOptNullNamedWorker extends sq.Worker
         super($TestOptNullNamedActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullNamedWorker.vm(
+  _$TestOptNullNamedWorker.vm(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -1783,7 +5504,7 @@ base class TestOptNullNamedWorker extends sq.Worker
         super($TestOptNullNamedActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullNamedWorker.js(
+  _$TestOptNullNamedWorker.js(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -1791,7 +5512,7 @@ base class TestOptNullNamedWorker extends sq.Worker
         super($TestOptNullNamedActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullNamedWorker.wasm(
+  _$TestOptNullNamedWorker.wasm(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -1803,14 +5524,152 @@ base class TestOptNullNamedWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullNamed
+base class TestOptNullNamedWorker
+    with Releasable
+    implements _$TestOptNullNamedWorker {
+  TestOptNullNamedWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullNamedWorker(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedWorker(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullNamedWorker.vm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedWorker.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullNamedWorker.js(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedWorker.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullNamedWorker.wasm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedWorker.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  final _$TestOptNullNamedWorker _$worker;
+
+  static final Finalizer<_$TestOptNullNamedWorker> _finalizer =
+      Finalizer<_$TestOptNullNamedWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullNamed
-base class TestOptNullNamedWorkerPool
+base class _$TestOptNullNamedWorkerPool
     extends sq.WorkerPool<TestOptNullNamedWorker>
     with _$TestOptNullNamed$Facade
     implements TestOptNullNamed {
-  TestOptNullNamedWorkerPool(
+  _$TestOptNullNamedWorkerPool(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1823,7 +5682,7 @@ base class TestOptNullNamedWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullNamedWorkerPool.vm(
+  _$TestOptNullNamedWorkerPool.vm(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1836,7 +5695,7 @@ base class TestOptNullNamedWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullNamedWorkerPool.js(
+  _$TestOptNullNamedWorkerPool.js(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1849,7 +5708,7 @@ base class TestOptNullNamedWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullNamedWorkerPool.wasm(
+  _$TestOptNullNamedWorkerPool.wasm(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1862,6 +5721,167 @@ base class TestOptNullNamedWorkerPool
                     exceptionManager: exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullNamed
+base class TestOptNullNamedWorkerPool
+    with Releasable
+    implements _$TestOptNullNamedWorkerPool {
+  TestOptNullNamedWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullNamedWorkerPool(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedWorkerPool(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullNamedWorkerPool.vm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedWorkerPool.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullNamedWorkerPool.js(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedWorkerPool.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullNamedWorkerPool.wasm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedWorkerPool.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestOptNullNamedWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullNamedWorkerPool> _finalizer =
+      Finalizer<_$TestOptNullNamedWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestOptNullNamedWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(TestOptNullNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(TestOptNullNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -1895,10 +5915,10 @@ sq.WorkerService $TestOptDefNamedInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestOptDefNamed
-base class TestOptDefNamedWorker extends sq.Worker
+base class _$TestOptDefNamedWorker extends sq.Worker
     with _$TestOptDefNamed$Invoker, _$TestOptDefNamed$Facade
     implements TestOptDefNamed {
-  TestOptDefNamedWorker(
+  _$TestOptDefNamedWorker(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -1906,7 +5926,7 @@ base class TestOptDefNamedWorker extends sq.Worker
         super($TestOptDefNamedActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefNamedWorker.vm(
+  _$TestOptDefNamedWorker.vm(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -1914,7 +5934,7 @@ base class TestOptDefNamedWorker extends sq.Worker
         super($TestOptDefNamedActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefNamedWorker.js(
+  _$TestOptDefNamedWorker.js(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -1922,7 +5942,7 @@ base class TestOptDefNamedWorker extends sq.Worker
         super($TestOptDefNamedActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefNamedWorker.wasm(
+  _$TestOptDefNamedWorker.wasm(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -1934,14 +5954,152 @@ base class TestOptDefNamedWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptDefNamed
+base class TestOptDefNamedWorker
+    with Releasable
+    implements _$TestOptDefNamedWorker {
+  TestOptDefNamedWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptDefNamedWorker(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedWorker(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptDefNamedWorker.vm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedWorker.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptDefNamedWorker.js(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedWorker.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptDefNamedWorker.wasm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedWorker.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  final _$TestOptDefNamedWorker _$worker;
+
+  static final Finalizer<_$TestOptDefNamedWorker> _finalizer =
+      Finalizer<_$TestOptDefNamedWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptDefNamed
-base class TestOptDefNamedWorkerPool
+base class _$TestOptDefNamedWorkerPool
     extends sq.WorkerPool<TestOptDefNamedWorker>
     with _$TestOptDefNamed$Facade
     implements TestOptDefNamed {
-  TestOptDefNamedWorkerPool(
+  _$TestOptDefNamedWorkerPool(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1954,7 +6112,7 @@ base class TestOptDefNamedWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefNamedWorkerPool.vm(
+  _$TestOptDefNamedWorkerPool.vm(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1967,7 +6125,7 @@ base class TestOptDefNamedWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefNamedWorkerPool.js(
+  _$TestOptDefNamedWorkerPool.js(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1980,7 +6138,7 @@ base class TestOptDefNamedWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefNamedWorkerPool.wasm(
+  _$TestOptDefNamedWorkerPool.wasm(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -1993,6 +6151,167 @@ base class TestOptDefNamedWorkerPool
                     exceptionManager: exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptDefNamed
+base class TestOptDefNamedWorkerPool
+    with Releasable
+    implements _$TestOptDefNamedWorkerPool {
+  TestOptDefNamedWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptDefNamedWorkerPool(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedWorkerPool(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptDefNamedWorkerPool.vm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedWorkerPool.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptDefNamedWorkerPool.js(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedWorkerPool.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptDefNamedWorkerPool.wasm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedWorkerPool.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestOptDefNamedWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptDefNamedWorkerPool> _finalizer =
+      Finalizer<_$TestOptDefNamedWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestOptDefNamedWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(TestOptDefNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(TestOptDefNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptDefNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptDefNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -2027,10 +6346,10 @@ sq.WorkerService $TestOptNullDefNamedInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestOptNullDefNamed
-base class TestOptNullDefNamedWorker extends sq.Worker
+base class _$TestOptNullDefNamedWorker extends sq.Worker
     with _$TestOptNullDefNamed$Invoker, _$TestOptNullDefNamed$Facade
     implements TestOptNullDefNamed {
-  TestOptNullDefNamedWorker(
+  _$TestOptNullDefNamedWorker(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2038,7 +6357,7 @@ base class TestOptNullDefNamedWorker extends sq.Worker
         super($TestOptNullDefNamedActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedWorker.vm(
+  _$TestOptNullDefNamedWorker.vm(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2046,7 +6365,7 @@ base class TestOptNullDefNamedWorker extends sq.Worker
         super($TestOptNullDefNamedActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedWorker.js(
+  _$TestOptNullDefNamedWorker.js(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2054,7 +6373,7 @@ base class TestOptNullDefNamedWorker extends sq.Worker
         super($TestOptNullDefNamedActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedWorker.wasm(
+  _$TestOptNullDefNamedWorker.wasm(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2066,14 +6385,152 @@ base class TestOptNullDefNamedWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullDefNamed
+base class TestOptNullDefNamedWorker
+    with Releasable
+    implements _$TestOptNullDefNamedWorker {
+  TestOptNullDefNamedWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullDefNamedWorker(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedWorker(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedWorker.vm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedWorker.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedWorker.js(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedWorker.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedWorker.wasm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedWorker.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  final _$TestOptNullDefNamedWorker _$worker;
+
+  static final Finalizer<_$TestOptNullDefNamedWorker> _finalizer =
+      Finalizer<_$TestOptNullDefNamedWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullDefNamed
-base class TestOptNullDefNamedWorkerPool
+base class _$TestOptNullDefNamedWorkerPool
     extends sq.WorkerPool<TestOptNullDefNamedWorker>
     with _$TestOptNullDefNamed$Facade
     implements TestOptNullDefNamed {
-  TestOptNullDefNamedWorkerPool(
+  _$TestOptNullDefNamedWorkerPool(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2086,7 +6543,7 @@ base class TestOptNullDefNamedWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedWorkerPool.vm(
+  _$TestOptNullDefNamedWorkerPool.vm(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2100,7 +6557,7 @@ base class TestOptNullDefNamedWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedWorkerPool.js(
+  _$TestOptNullDefNamedWorkerPool.js(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2114,7 +6571,7 @@ base class TestOptNullDefNamedWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedWorkerPool.wasm(
+  _$TestOptNullDefNamedWorkerPool.wasm(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2127,6 +6584,168 @@ base class TestOptNullDefNamedWorkerPool
                     exceptionManager: exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullDefNamed
+base class TestOptNullDefNamedWorkerPool
+    with Releasable
+    implements _$TestOptNullDefNamedWorkerPool {
+  TestOptNullDefNamedWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullDefNamedWorkerPool(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedWorkerPool(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullDefNamedWorkerPool.vm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedWorkerPool.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullDefNamedWorkerPool.js(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedWorkerPool.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullDefNamedWorkerPool.wasm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedWorkerPool.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestOptNullDefNamedWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullDefNamedWorkerPool> _finalizer =
+      Finalizer<_$TestOptNullDefNamedWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestOptNullDefNamedWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptNullDefNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(TestOptNullDefNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullDefNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullDefNamedWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -2161,10 +6780,10 @@ sq.WorkerService $TestOptNullNamedFieldInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestOptNullNamedField
-base class TestOptNullNamedFieldWorker extends sq.Worker
+base class _$TestOptNullNamedFieldWorker extends sq.Worker
     with _$TestOptNullNamedField$Invoker, _$TestOptNullNamedField$Facade
     implements TestOptNullNamedField {
-  TestOptNullNamedFieldWorker(
+  _$TestOptNullNamedFieldWorker(
       {this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2172,7 +6791,7 @@ base class TestOptNullNamedFieldWorker extends sq.Worker
         super($TestOptNullNamedFieldActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullNamedFieldWorker.vm(
+  _$TestOptNullNamedFieldWorker.vm(
       {this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2180,7 +6799,7 @@ base class TestOptNullNamedFieldWorker extends sq.Worker
         super($TestOptNullNamedFieldActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullNamedFieldWorker.js(
+  _$TestOptNullNamedFieldWorker.js(
       {this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2188,7 +6807,7 @@ base class TestOptNullNamedFieldWorker extends sq.Worker
         super($TestOptNullNamedFieldActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullNamedFieldWorker.wasm(
+  _$TestOptNullNamedFieldWorker.wasm(
       {this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2203,14 +6822,155 @@ base class TestOptNullNamedFieldWorker extends sq.Worker
 
   @override
   final int? arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullNamedField
+base class TestOptNullNamedFieldWorker
+    with Releasable
+    implements _$TestOptNullNamedFieldWorker {
+  TestOptNullNamedFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullNamedFieldWorker(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedFieldWorker(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullNamedFieldWorker.vm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedFieldWorker.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullNamedFieldWorker.js(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedFieldWorker.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullNamedFieldWorker.wasm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedFieldWorker.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  @override
+  int? get arg1 => _$worker.arg1;
+
+  final _$TestOptNullNamedFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptNullNamedFieldWorker> _finalizer =
+      Finalizer<_$TestOptNullNamedFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullNamedField
-base class TestOptNullNamedFieldWorkerPool
+base class _$TestOptNullNamedFieldWorkerPool
     extends sq.WorkerPool<TestOptNullNamedFieldWorker>
     with _$TestOptNullNamedField$Facade
     implements TestOptNullNamedField {
-  TestOptNullNamedFieldWorkerPool(
+  _$TestOptNullNamedFieldWorkerPool(
       {this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2224,7 +6984,7 @@ base class TestOptNullNamedFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullNamedFieldWorkerPool.vm(
+  _$TestOptNullNamedFieldWorkerPool.vm(
       {this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2238,7 +6998,7 @@ base class TestOptNullNamedFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullNamedFieldWorkerPool.js(
+  _$TestOptNullNamedFieldWorkerPool.js(
       {this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2252,7 +7012,7 @@ base class TestOptNullNamedFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullNamedFieldWorkerPool.wasm(
+  _$TestOptNullNamedFieldWorkerPool.wasm(
       {this.arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2268,6 +7028,172 @@ base class TestOptNullNamedFieldWorkerPool
 
   @override
   final int? arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullNamedField
+base class TestOptNullNamedFieldWorkerPool
+    with Releasable
+    implements _$TestOptNullNamedFieldWorkerPool {
+  TestOptNullNamedFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullNamedFieldWorkerPool(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedFieldWorkerPool(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullNamedFieldWorkerPool.vm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedFieldWorkerPool.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullNamedFieldWorkerPool.js(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedFieldWorkerPool.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullNamedFieldWorkerPool.wasm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedFieldWorkerPool.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  @override
+  int? get arg1 => _$pool.arg1;
+
+  final _$TestOptNullNamedFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullNamedFieldWorkerPool> _finalizer =
+      Finalizer<_$TestOptNullNamedFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestOptNullNamedFieldWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptNullNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptNullNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -2302,10 +7228,10 @@ sq.WorkerService $TestOptDefNamedFieldInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestOptDefNamedField
-base class TestOptDefNamedFieldWorker extends sq.Worker
+base class _$TestOptDefNamedFieldWorker extends sq.Worker
     with _$TestOptDefNamedField$Invoker, _$TestOptDefNamedField$Facade
     implements TestOptDefNamedField {
-  TestOptDefNamedFieldWorker(
+  _$TestOptDefNamedFieldWorker(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2313,7 +7239,7 @@ base class TestOptDefNamedFieldWorker extends sq.Worker
         super($TestOptDefNamedFieldActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefNamedFieldWorker.vm(
+  _$TestOptDefNamedFieldWorker.vm(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2321,7 +7247,7 @@ base class TestOptDefNamedFieldWorker extends sq.Worker
         super($TestOptDefNamedFieldActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefNamedFieldWorker.js(
+  _$TestOptDefNamedFieldWorker.js(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2329,7 +7255,7 @@ base class TestOptDefNamedFieldWorker extends sq.Worker
         super($TestOptDefNamedFieldActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefNamedFieldWorker.wasm(
+  _$TestOptDefNamedFieldWorker.wasm(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2344,14 +7270,155 @@ base class TestOptDefNamedFieldWorker extends sq.Worker
 
   @override
   final int arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptDefNamedField
+base class TestOptDefNamedFieldWorker
+    with Releasable
+    implements _$TestOptDefNamedFieldWorker {
+  TestOptDefNamedFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptDefNamedFieldWorker(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedFieldWorker(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptDefNamedFieldWorker.vm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedFieldWorker.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptDefNamedFieldWorker.js(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedFieldWorker.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptDefNamedFieldWorker.wasm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedFieldWorker.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  @override
+  int get arg1 => _$worker.arg1;
+
+  final _$TestOptDefNamedFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptDefNamedFieldWorker> _finalizer =
+      Finalizer<_$TestOptDefNamedFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptDefNamedField
-base class TestOptDefNamedFieldWorkerPool
+base class _$TestOptDefNamedFieldWorkerPool
     extends sq.WorkerPool<TestOptDefNamedFieldWorker>
     with _$TestOptDefNamedField$Facade
     implements TestOptDefNamedField {
-  TestOptDefNamedFieldWorkerPool(
+  _$TestOptDefNamedFieldWorkerPool(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2365,7 +7432,7 @@ base class TestOptDefNamedFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefNamedFieldWorkerPool.vm(
+  _$TestOptDefNamedFieldWorkerPool.vm(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2379,7 +7446,7 @@ base class TestOptDefNamedFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefNamedFieldWorkerPool.js(
+  _$TestOptDefNamedFieldWorkerPool.js(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2393,7 +7460,7 @@ base class TestOptDefNamedFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefNamedFieldWorkerPool.wasm(
+  _$TestOptDefNamedFieldWorkerPool.wasm(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2409,6 +7476,172 @@ base class TestOptDefNamedFieldWorkerPool
 
   @override
   final int arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptDefNamedField
+base class TestOptDefNamedFieldWorkerPool
+    with Releasable
+    implements _$TestOptDefNamedFieldWorkerPool {
+  TestOptDefNamedFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptDefNamedFieldWorkerPool(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedFieldWorkerPool(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptDefNamedFieldWorkerPool.vm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedFieldWorkerPool.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptDefNamedFieldWorkerPool.js(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedFieldWorkerPool.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptDefNamedFieldWorkerPool.wasm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedFieldWorkerPool.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  @override
+  int get arg1 => _$pool.arg1;
+
+  final _$TestOptDefNamedFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptDefNamedFieldWorkerPool> _finalizer =
+      Finalizer<_$TestOptDefNamedFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestOptDefNamedFieldWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptDefNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptDefNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptDefNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptDefNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -2443,10 +7676,10 @@ sq.WorkerService $TestOptNullDefNamedFieldInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestOptNullDefNamedField
-base class TestOptNullDefNamedFieldWorker extends sq.Worker
+base class _$TestOptNullDefNamedFieldWorker extends sq.Worker
     with _$TestOptNullDefNamedField$Invoker, _$TestOptNullDefNamedField$Facade
     implements TestOptNullDefNamedField {
-  TestOptNullDefNamedFieldWorker(
+  _$TestOptNullDefNamedFieldWorker(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2454,7 +7687,7 @@ base class TestOptNullDefNamedFieldWorker extends sq.Worker
         super($TestOptNullDefNamedFieldActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedFieldWorker.vm(
+  _$TestOptNullDefNamedFieldWorker.vm(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2462,7 +7695,7 @@ base class TestOptNullDefNamedFieldWorker extends sq.Worker
         super($TestOptNullDefNamedFieldActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedFieldWorker.js(
+  _$TestOptNullDefNamedFieldWorker.js(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2470,7 +7703,7 @@ base class TestOptNullDefNamedFieldWorker extends sq.Worker
         super($TestOptNullDefNamedFieldActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedFieldWorker.wasm(
+  _$TestOptNullDefNamedFieldWorker.wasm(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2485,14 +7718,155 @@ base class TestOptNullDefNamedFieldWorker extends sq.Worker
 
   @override
   final int? arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullDefNamedField
+base class TestOptNullDefNamedFieldWorker
+    with Releasable
+    implements _$TestOptNullDefNamedFieldWorker {
+  TestOptNullDefNamedFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullDefNamedFieldWorker(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedFieldWorker(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedFieldWorker.vm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedFieldWorker.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedFieldWorker.js(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedFieldWorker.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedFieldWorker.wasm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedFieldWorker.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  @override
+  int? get arg1 => _$worker.arg1;
+
+  final _$TestOptNullDefNamedFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptNullDefNamedFieldWorker> _finalizer =
+      Finalizer<_$TestOptNullDefNamedFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullDefNamedField
-base class TestOptNullDefNamedFieldWorkerPool
+base class _$TestOptNullDefNamedFieldWorkerPool
     extends sq.WorkerPool<TestOptNullDefNamedFieldWorker>
     with _$TestOptNullDefNamedField$Facade
     implements TestOptNullDefNamedField {
-  TestOptNullDefNamedFieldWorkerPool(
+  _$TestOptNullDefNamedFieldWorkerPool(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2506,7 +7880,7 @@ base class TestOptNullDefNamedFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedFieldWorkerPool.vm(
+  _$TestOptNullDefNamedFieldWorkerPool.vm(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2520,7 +7894,7 @@ base class TestOptNullDefNamedFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedFieldWorkerPool.js(
+  _$TestOptNullDefNamedFieldWorkerPool.js(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2534,7 +7908,7 @@ base class TestOptNullDefNamedFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedFieldWorkerPool.wasm(
+  _$TestOptNullDefNamedFieldWorkerPool.wasm(
       {this.arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2550,6 +7924,172 @@ base class TestOptNullDefNamedFieldWorkerPool
 
   @override
   final int? arg1;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullDefNamedField
+base class TestOptNullDefNamedFieldWorkerPool
+    with Releasable
+    implements _$TestOptNullDefNamedFieldWorkerPool {
+  TestOptNullDefNamedFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullDefNamedFieldWorkerPool(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedFieldWorkerPool(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullDefNamedFieldWorkerPool.vm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedFieldWorkerPool.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullDefNamedFieldWorkerPool.js(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedFieldWorkerPool.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullDefNamedFieldWorkerPool.wasm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedFieldWorkerPool.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  @override
+  int? get arg1 => _$pool.arg1;
+
+  final _$TestOptNullDefNamedFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullDefNamedFieldWorkerPool> _finalizer =
+      Finalizer<_$TestOptNullDefNamedFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestOptNullDefNamedFieldWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptNullDefNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptNullDefNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullDefNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullDefNamedFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -2643,28 +8183,28 @@ sq.WorkerService $TestTypedDataInitializer(sq.WorkerRequest $req) =>
     _$TestTypedData$WorkerService();
 
 /// Worker for TestTypedData
-base class TestTypedDataWorker extends sq.Worker
+base class _$TestTypedDataWorker extends sq.Worker
     with _$TestTypedData$Invoker, _$TestTypedData$Facade
     implements TestTypedData {
-  TestTypedDataWorker(
+  _$TestTypedDataWorker(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestTypedDataActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestTypedDataWorker.vm(
+  _$TestTypedDataWorker.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestTypedDataActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestTypedDataWorker.js(
+  _$TestTypedDataWorker.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestTypedDataActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestTypedDataWorker.wasm(
+  _$TestTypedDataWorker.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestTypedDataActivator(sq.SquadronPlatformType.wasm),
@@ -2672,13 +8212,159 @@ base class TestTypedDataWorker extends sq.Worker
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestTypedData
+base class TestTypedDataWorker
+    with Releasable
+    implements _$TestTypedDataWorker {
+  TestTypedDataWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestTypedDataWorker(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestTypedDataWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestTypedDataWorker.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestTypedDataWorker.vm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestTypedDataWorker.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestTypedDataWorker.js(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestTypedDataWorker.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestTypedDataWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$TestTypedDataWorker _$worker;
+
+  static final Finalizer<_$TestTypedDataWorker> _finalizer =
+      Finalizer<_$TestTypedDataWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<typed_data.ByteBuffer?> bar(List<int> bytes,
+          {String? title,
+          bool isLandscape = true,
+          List<String>? columns,
+          Map<int, double>? columnWidths,
+          typed_data.ByteData? fontData,
+          Map<int, typed_data.ByteData>? titleFonts,
+          Map<int, typed_data.ByteData>? dataFonts}) =>
+      _$worker.bar(bytes,
+          title: title,
+          isLandscape: isLandscape,
+          columns: columns,
+          columnWidths: columnWidths,
+          fontData: fontData,
+          titleFonts: titleFonts,
+          dataFonts: dataFonts);
+
+  @override
+  Future<typed_data.Uint8List?> foo(List<int> bytes,
+          {bool isLandscape = true}) =>
+      _$worker.foo(bytes, isLandscape: isLandscape);
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestTypedData
-base class TestTypedDataWorkerPool extends sq.WorkerPool<TestTypedDataWorker>
+base class _$TestTypedDataWorkerPool extends sq.WorkerPool<TestTypedDataWorker>
     with _$TestTypedData$Facade
     implements TestTypedData {
-  TestTypedDataWorkerPool(
+  _$TestTypedDataWorkerPool(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -2688,7 +8374,7 @@ base class TestTypedDataWorkerPool extends sq.WorkerPool<TestTypedDataWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestTypedDataWorkerPool.vm(
+  _$TestTypedDataWorkerPool.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -2698,7 +8384,7 @@ base class TestTypedDataWorkerPool extends sq.WorkerPool<TestTypedDataWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestTypedDataWorkerPool.js(
+  _$TestTypedDataWorkerPool.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -2708,7 +8394,7 @@ base class TestTypedDataWorkerPool extends sq.WorkerPool<TestTypedDataWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestTypedDataWorkerPool.wasm(
+  _$TestTypedDataWorkerPool.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -2740,6 +8426,182 @@ base class TestTypedDataWorkerPool extends sq.WorkerPool<TestTypedDataWorker>
   Future<typed_data.Uint8List?> foo(List<int> bytes,
           {bool isLandscape = true}) =>
       execute((w) => w.foo(bytes, isLandscape: isLandscape));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestTypedData
+base class TestTypedDataWorkerPool
+    with Releasable
+    implements _$TestTypedDataWorkerPool {
+  TestTypedDataWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestTypedDataWorkerPool(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestTypedDataWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestTypedDataWorkerPool.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestTypedDataWorkerPool.vm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestTypedDataWorkerPool.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestTypedDataWorkerPool.js(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestTypedDataWorkerPool.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestTypedDataWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestTypedDataWorkerPool _$pool;
+
+  static final Finalizer<_$TestTypedDataWorkerPool> _finalizer =
+      Finalizer<_$TestTypedDataWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<typed_data.ByteBuffer?> bar(List<int> bytes,
+          {String? title,
+          bool isLandscape = true,
+          List<String>? columns,
+          Map<int, double>? columnWidths,
+          typed_data.ByteData? fontData,
+          Map<int, typed_data.ByteData>? titleFonts,
+          Map<int, typed_data.ByteData>? dataFonts}) =>
+      _$pool.bar(bytes,
+          title: title,
+          isLandscape: isLandscape,
+          columns: columns,
+          columnWidths: columnWidths,
+          fontData: fontData,
+          titleFonts: titleFonts,
+          dataFonts: dataFonts);
+
+  @override
+  Future<typed_data.Uint8List?> foo(List<int> bytes,
+          {bool isLandscape = true}) =>
+      _$pool.foo(bytes, isLandscape: isLandscape);
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestTypedDataWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(TestTypedDataWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(TestTypedDataWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestTypedDataWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestTypedDataWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -2781,12 +8643,12 @@ sq.WorkerService $TestOptNullNamedPrivateFieldInitializer(
 }
 
 /// Worker for TestOptNullNamedPrivateField
-base class TestOptNullNamedPrivateFieldWorker extends sq.Worker
+base class _$TestOptNullNamedPrivateFieldWorker extends sq.Worker
     with
         _$TestOptNullNamedPrivateField$Invoker,
         _$TestOptNullNamedPrivateField$Facade
     implements TestOptNullNamedPrivateField {
-  TestOptNullNamedPrivateFieldWorker(
+  _$TestOptNullNamedPrivateFieldWorker(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2794,7 +8656,7 @@ base class TestOptNullNamedPrivateFieldWorker extends sq.Worker
         super($TestOptNullNamedPrivateFieldActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptNullNamedPrivateFieldWorker.vm(
+  _$TestOptNullNamedPrivateFieldWorker.vm(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2804,7 +8666,7 @@ base class TestOptNullNamedPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullNamedPrivateFieldWorker.js(
+  _$TestOptNullNamedPrivateFieldWorker.js(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2814,7 +8676,7 @@ base class TestOptNullNamedPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullNamedPrivateFieldWorker.wasm(
+  _$TestOptNullNamedPrivateFieldWorker.wasm(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2829,14 +8691,155 @@ base class TestOptNullNamedPrivateFieldWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullNamedPrivateField
+base class TestOptNullNamedPrivateFieldWorker
+    with Releasable
+    implements _$TestOptNullNamedPrivateFieldWorker {
+  TestOptNullNamedPrivateFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullNamedPrivateFieldWorker(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedPrivateFieldWorker(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullNamedPrivateFieldWorker.vm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedPrivateFieldWorker.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullNamedPrivateFieldWorker.js(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedPrivateFieldWorker.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullNamedPrivateFieldWorker.wasm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullNamedPrivateFieldWorker.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  final _$TestOptNullNamedPrivateFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptNullNamedPrivateFieldWorker> _finalizer =
+      Finalizer<_$TestOptNullNamedPrivateFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  int? get _arg1 => _$worker._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullNamedPrivateField
-base class TestOptNullNamedPrivateFieldWorkerPool
+base class _$TestOptNullNamedPrivateFieldWorkerPool
     extends sq.WorkerPool<TestOptNullNamedPrivateFieldWorker>
     with _$TestOptNullNamedPrivateField$Facade
     implements TestOptNullNamedPrivateField {
-  TestOptNullNamedPrivateFieldWorkerPool(
+  _$TestOptNullNamedPrivateFieldWorkerPool(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2850,7 +8853,7 @@ base class TestOptNullNamedPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullNamedPrivateFieldWorkerPool.vm(
+  _$TestOptNullNamedPrivateFieldWorkerPool.vm(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2864,7 +8867,7 @@ base class TestOptNullNamedPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullNamedPrivateFieldWorkerPool.js(
+  _$TestOptNullNamedPrivateFieldWorkerPool.js(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2878,7 +8881,7 @@ base class TestOptNullNamedPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullNamedPrivateFieldWorkerPool.wasm(
+  _$TestOptNullNamedPrivateFieldWorkerPool.wasm(
       {int? arg1,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2891,6 +8894,174 @@ base class TestOptNullNamedPrivateFieldWorkerPool
                     exceptionManager: exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullNamedPrivateField
+base class TestOptNullNamedPrivateFieldWorkerPool
+    with Releasable
+    implements _$TestOptNullNamedPrivateFieldWorkerPool {
+  TestOptNullNamedPrivateFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullNamedPrivateFieldWorkerPool(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedPrivateFieldWorkerPool(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullNamedPrivateFieldWorkerPool.vm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedPrivateFieldWorkerPool.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullNamedPrivateFieldWorkerPool.js(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedPrivateFieldWorkerPool.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullNamedPrivateFieldWorkerPool.wasm(
+      {int? arg1,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullNamedPrivateFieldWorkerPool.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestOptNullNamedPrivateFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullNamedPrivateFieldWorkerPool> _finalizer =
+      Finalizer<_$TestOptNullNamedPrivateFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  int? get _arg1 => _$pool._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop(
+          [bool Function(TestOptNullNamedPrivateFieldWorker worker)?
+              predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptNullNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptNullNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -2932,12 +9103,12 @@ sq.WorkerService $TestOptDefNamedPrivateFieldInitializer(
 }
 
 /// Worker for TestOptDefNamedPrivateField
-base class TestOptDefNamedPrivateFieldWorker extends sq.Worker
+base class _$TestOptDefNamedPrivateFieldWorker extends sq.Worker
     with
         _$TestOptDefNamedPrivateField$Invoker,
         _$TestOptDefNamedPrivateField$Facade
     implements TestOptDefNamedPrivateField {
-  TestOptDefNamedPrivateFieldWorker(
+  _$TestOptDefNamedPrivateFieldWorker(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2945,7 +9116,7 @@ base class TestOptDefNamedPrivateFieldWorker extends sq.Worker
         super($TestOptDefNamedPrivateFieldActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefNamedPrivateFieldWorker.vm(
+  _$TestOptDefNamedPrivateFieldWorker.vm(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2953,7 +9124,7 @@ base class TestOptDefNamedPrivateFieldWorker extends sq.Worker
         super($TestOptDefNamedPrivateFieldActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefNamedPrivateFieldWorker.js(
+  _$TestOptDefNamedPrivateFieldWorker.js(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2961,7 +9132,7 @@ base class TestOptDefNamedPrivateFieldWorker extends sq.Worker
         super($TestOptDefNamedPrivateFieldActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestOptDefNamedPrivateFieldWorker.wasm(
+  _$TestOptDefNamedPrivateFieldWorker.wasm(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -2975,14 +9146,155 @@ base class TestOptDefNamedPrivateFieldWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptDefNamedPrivateField
+base class TestOptDefNamedPrivateFieldWorker
+    with Releasable
+    implements _$TestOptDefNamedPrivateFieldWorker {
+  TestOptDefNamedPrivateFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptDefNamedPrivateFieldWorker(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedPrivateFieldWorker(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptDefNamedPrivateFieldWorker.vm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedPrivateFieldWorker.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptDefNamedPrivateFieldWorker.js(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedPrivateFieldWorker.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptDefNamedPrivateFieldWorker.wasm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptDefNamedPrivateFieldWorker.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  final _$TestOptDefNamedPrivateFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptDefNamedPrivateFieldWorker> _finalizer =
+      Finalizer<_$TestOptDefNamedPrivateFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  int get _arg1 => _$worker._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptDefNamedPrivateField
-base class TestOptDefNamedPrivateFieldWorkerPool
+base class _$TestOptDefNamedPrivateFieldWorkerPool
     extends sq.WorkerPool<TestOptDefNamedPrivateFieldWorker>
     with _$TestOptDefNamedPrivateField$Facade
     implements TestOptDefNamedPrivateField {
-  TestOptDefNamedPrivateFieldWorkerPool(
+  _$TestOptDefNamedPrivateFieldWorkerPool(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -2996,7 +9308,7 @@ base class TestOptDefNamedPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefNamedPrivateFieldWorkerPool.vm(
+  _$TestOptDefNamedPrivateFieldWorkerPool.vm(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -3010,7 +9322,7 @@ base class TestOptDefNamedPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefNamedPrivateFieldWorkerPool.js(
+  _$TestOptDefNamedPrivateFieldWorkerPool.js(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -3024,7 +9336,7 @@ base class TestOptDefNamedPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptDefNamedPrivateFieldWorkerPool.wasm(
+  _$TestOptDefNamedPrivateFieldWorkerPool.wasm(
       {int arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -3037,6 +9349,174 @@ base class TestOptDefNamedPrivateFieldWorkerPool
                     exceptionManager: exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptDefNamedPrivateField
+base class TestOptDefNamedPrivateFieldWorkerPool
+    with Releasable
+    implements _$TestOptDefNamedPrivateFieldWorkerPool {
+  TestOptDefNamedPrivateFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptDefNamedPrivateFieldWorkerPool(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedPrivateFieldWorkerPool(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptDefNamedPrivateFieldWorkerPool.vm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedPrivateFieldWorkerPool.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptDefNamedPrivateFieldWorkerPool.js(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedPrivateFieldWorkerPool.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptDefNamedPrivateFieldWorkerPool.wasm(
+      {int arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptDefNamedPrivateFieldWorkerPool.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestOptDefNamedPrivateFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptDefNamedPrivateFieldWorkerPool> _finalizer =
+      Finalizer<_$TestOptDefNamedPrivateFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  int get _arg1 => _$pool._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop(
+          [bool Function(TestOptDefNamedPrivateFieldWorker worker)?
+              predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptDefNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptDefNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptDefNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptDefNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -3078,12 +9558,12 @@ sq.WorkerService $TestOptNullDefNamedPrivateFieldInitializer(
 }
 
 /// Worker for TestOptNullDefNamedPrivateField
-base class TestOptNullDefNamedPrivateFieldWorker extends sq.Worker
+base class _$TestOptNullDefNamedPrivateFieldWorker extends sq.Worker
     with
         _$TestOptNullDefNamedPrivateField$Invoker,
         _$TestOptNullDefNamedPrivateField$Facade
     implements TestOptNullDefNamedPrivateField {
-  TestOptNullDefNamedPrivateFieldWorker(
+  _$TestOptNullDefNamedPrivateFieldWorker(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3093,7 +9573,7 @@ base class TestOptNullDefNamedPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedPrivateFieldWorker.vm(
+  _$TestOptNullDefNamedPrivateFieldWorker.vm(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3104,7 +9584,7 @@ base class TestOptNullDefNamedPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedPrivateFieldWorker.js(
+  _$TestOptNullDefNamedPrivateFieldWorker.js(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3115,7 +9595,7 @@ base class TestOptNullDefNamedPrivateFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedPrivateFieldWorker.wasm(
+  _$TestOptNullDefNamedPrivateFieldWorker.wasm(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3130,14 +9610,155 @@ base class TestOptNullDefNamedPrivateFieldWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullDefNamedPrivateField
+base class TestOptNullDefNamedPrivateFieldWorker
+    with Releasable
+    implements _$TestOptNullDefNamedPrivateFieldWorker {
+  TestOptNullDefNamedPrivateFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullDefNamedPrivateFieldWorker(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedPrivateFieldWorker(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedPrivateFieldWorker.vm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedPrivateFieldWorker.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedPrivateFieldWorker.js(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedPrivateFieldWorker.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedPrivateFieldWorker.wasm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedPrivateFieldWorker.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  final _$TestOptNullDefNamedPrivateFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptNullDefNamedPrivateFieldWorker> _finalizer =
+      Finalizer<_$TestOptNullDefNamedPrivateFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  int? get _arg1 => _$worker._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestOptNullDefNamedPrivateField
-base class TestOptNullDefNamedPrivateFieldWorkerPool
+base class _$TestOptNullDefNamedPrivateFieldWorkerPool
     extends sq.WorkerPool<TestOptNullDefNamedPrivateFieldWorker>
     with _$TestOptNullDefNamedPrivateField$Facade
     implements TestOptNullDefNamedPrivateField {
-  TestOptNullDefNamedPrivateFieldWorkerPool(
+  _$TestOptNullDefNamedPrivateFieldWorkerPool(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -3151,7 +9772,7 @@ base class TestOptNullDefNamedPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedPrivateFieldWorkerPool.vm(
+  _$TestOptNullDefNamedPrivateFieldWorkerPool.vm(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -3165,7 +9786,7 @@ base class TestOptNullDefNamedPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedPrivateFieldWorkerPool.js(
+  _$TestOptNullDefNamedPrivateFieldWorkerPool.js(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -3179,7 +9800,7 @@ base class TestOptNullDefNamedPrivateFieldWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedPrivateFieldWorkerPool.wasm(
+  _$TestOptNullDefNamedPrivateFieldWorkerPool.wasm(
       {int? arg1 = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -3192,6 +9813,174 @@ base class TestOptNullDefNamedPrivateFieldWorkerPool
                     exceptionManager: exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestOptNullDefNamedPrivateField
+base class TestOptNullDefNamedPrivateFieldWorkerPool
+    with Releasable
+    implements _$TestOptNullDefNamedPrivateFieldWorkerPool {
+  TestOptNullDefNamedPrivateFieldWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestOptNullDefNamedPrivateFieldWorkerPool(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedPrivateFieldWorkerPool(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullDefNamedPrivateFieldWorkerPool.vm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedPrivateFieldWorkerPool.vm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullDefNamedPrivateFieldWorkerPool.js(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedPrivateFieldWorkerPool.js(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestOptNullDefNamedPrivateFieldWorkerPool.wasm(
+      {int? arg1 = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestOptNullDefNamedPrivateFieldWorkerPool.wasm(
+            arg1: arg1,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestOptNullDefNamedPrivateFieldWorkerPool _$pool;
+
+  static final Finalizer<_$TestOptNullDefNamedPrivateFieldWorkerPool>
+      _finalizer = Finalizer<_$TestOptNullDefNamedPrivateFieldWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  int? get _arg1 => _$pool._arg1;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop(
+          [bool Function(TestOptNullDefNamedPrivateFieldWorker worker)?
+              predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestOptNullDefNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestOptNullDefNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestOptNullDefNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestOptNullDefNamedPrivateFieldWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -3238,10 +10027,10 @@ sq.WorkerService $TestPrefixedImportTypeInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestPrefixedImportType
-base class TestPrefixedImportTypeWorker extends sq.Worker
+base class _$TestPrefixedImportTypeWorker extends sq.Worker
     with _$TestPrefixedImportType$Invoker, _$TestPrefixedImportType$Facade
     implements TestPrefixedImportType {
-  TestPrefixedImportTypeWorker(this.typedData,
+  _$TestPrefixedImportTypeWorker(this.typedData,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = (() {
@@ -3251,7 +10040,7 @@ base class TestPrefixedImportTypeWorker extends sq.Worker
         super($TestPrefixedImportTypeActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestPrefixedImportTypeWorker.vm(this.typedData,
+  _$TestPrefixedImportTypeWorker.vm(this.typedData,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = (() {
@@ -3261,7 +10050,7 @@ base class TestPrefixedImportTypeWorker extends sq.Worker
         super($TestPrefixedImportTypeActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestPrefixedImportTypeWorker.js(this.typedData,
+  _$TestPrefixedImportTypeWorker.js(this.typedData,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = (() {
@@ -3271,7 +10060,7 @@ base class TestPrefixedImportTypeWorker extends sq.Worker
         super($TestPrefixedImportTypeActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestPrefixedImportTypeWorker.wasm(this.typedData,
+  _$TestPrefixedImportTypeWorker.wasm(this.typedData,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = (() {
@@ -3288,14 +10077,146 @@ base class TestPrefixedImportTypeWorker extends sq.Worker
 
   @override
   final typed_data.Int8List typedData;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestPrefixedImportType
+base class TestPrefixedImportTypeWorker
+    with Releasable
+    implements _$TestPrefixedImportTypeWorker {
+  TestPrefixedImportTypeWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestPrefixedImportTypeWorker(typed_data.Int8List typedData,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestPrefixedImportTypeWorker(typedData,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestPrefixedImportTypeWorker.vm(typed_data.Int8List typedData,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestPrefixedImportTypeWorker.vm(typedData,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestPrefixedImportTypeWorker.js(typed_data.Int8List typedData,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestPrefixedImportTypeWorker.js(typedData,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestPrefixedImportTypeWorker.wasm(typed_data.Int8List typedData,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestPrefixedImportTypeWorker.wasm(typedData,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  @override
+  typed_data.Int8List get typedData => _$worker.typedData;
+
+  final _$TestPrefixedImportTypeWorker _$worker;
+
+  static final Finalizer<_$TestPrefixedImportTypeWorker> _finalizer =
+      Finalizer<_$TestPrefixedImportTypeWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<typed_data.Int8List?> getTypedData() => _$worker.getTypedData();
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestPrefixedImportType
-base class TestPrefixedImportTypeWorkerPool
+base class _$TestPrefixedImportTypeWorkerPool
     extends sq.WorkerPool<TestPrefixedImportTypeWorker>
     with _$TestPrefixedImportType$Facade
     implements TestPrefixedImportType {
-  TestPrefixedImportTypeWorkerPool(this.typedData,
+  _$TestPrefixedImportTypeWorkerPool(this.typedData,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3306,7 +10227,7 @@ base class TestPrefixedImportTypeWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestPrefixedImportTypeWorkerPool.vm(this.typedData,
+  _$TestPrefixedImportTypeWorkerPool.vm(this.typedData,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3317,7 +10238,7 @@ base class TestPrefixedImportTypeWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestPrefixedImportTypeWorkerPool.js(this.typedData,
+  _$TestPrefixedImportTypeWorkerPool.js(this.typedData,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3328,7 +10249,7 @@ base class TestPrefixedImportTypeWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestPrefixedImportTypeWorkerPool.wasm(this.typedData,
+  _$TestPrefixedImportTypeWorkerPool.wasm(this.typedData,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3345,6 +10266,167 @@ base class TestPrefixedImportTypeWorkerPool
   @override
   Future<typed_data.Int8List?> getTypedData() =>
       execute((w) => w.getTypedData());
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestPrefixedImportType
+base class TestPrefixedImportTypeWorkerPool
+    with Releasable
+    implements _$TestPrefixedImportTypeWorkerPool {
+  TestPrefixedImportTypeWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestPrefixedImportTypeWorkerPool(typed_data.Int8List typedData,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestPrefixedImportTypeWorkerPool(typedData,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestPrefixedImportTypeWorkerPool.vm(typed_data.Int8List typedData,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestPrefixedImportTypeWorkerPool.vm(typedData,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestPrefixedImportTypeWorkerPool.js(typed_data.Int8List typedData,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestPrefixedImportTypeWorkerPool.js(typedData,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestPrefixedImportTypeWorkerPool.wasm(typed_data.Int8List typedData,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestPrefixedImportTypeWorkerPool.wasm(typedData,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  @override
+  typed_data.Int8List get typedData => _$pool.typedData;
+
+  final _$TestPrefixedImportTypeWorkerPool _$pool;
+
+  static final Finalizer<_$TestPrefixedImportTypeWorkerPool> _finalizer =
+      Finalizer<_$TestPrefixedImportTypeWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<typed_data.Int8List?> getTypedData() => _$pool.getTypedData();
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestPrefixedImportTypeWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestPrefixedImportTypeWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestPrefixedImportTypeWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestPrefixedImportTypeWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestPrefixedImportTypeWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -3412,12 +10494,12 @@ sq.WorkerService $TestOptNullDefNamedPrivateNonFinalFieldInitializer(
 }
 
 /// Worker for TestOptNullDefNamedPrivateNonFinalField
-base class TestOptNullDefNamedPrivateNonFinalFieldWorker extends sq.Worker
+base class _$TestOptNullDefNamedPrivateNonFinalFieldWorker extends sq.Worker
     with
         _$TestOptNullDefNamedPrivateNonFinalField$Invoker,
         _$TestOptNullDefNamedPrivateNonFinalField$Facade
     implements TestOptNullDefNamedPrivateNonFinalField {
-  TestOptNullDefNamedPrivateNonFinalFieldWorker(
+  _$TestOptNullDefNamedPrivateNonFinalFieldWorker(
       {int? state = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3428,7 +10510,7 @@ base class TestOptNullDefNamedPrivateNonFinalFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedPrivateNonFinalFieldWorker.vm(
+  _$TestOptNullDefNamedPrivateNonFinalFieldWorker.vm(
       {int? state = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3439,7 +10521,7 @@ base class TestOptNullDefNamedPrivateNonFinalFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedPrivateNonFinalFieldWorker.js(
+  _$TestOptNullDefNamedPrivateNonFinalFieldWorker.js(
       {int? state = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3450,7 +10532,7 @@ base class TestOptNullDefNamedPrivateNonFinalFieldWorker extends sq.Worker
             threadHook: threadHook,
             exceptionManager: exceptionManager);
 
-  TestOptNullDefNamedPrivateNonFinalFieldWorker.wasm(
+  _$TestOptNullDefNamedPrivateNonFinalFieldWorker.wasm(
       {int? state = 0,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3465,6 +10547,157 @@ base class TestOptNullDefNamedPrivateNonFinalFieldWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestOptNullDefNamedPrivateNonFinalField
+base class TestOptNullDefNamedPrivateNonFinalFieldWorker
+    with Releasable
+    implements _$TestOptNullDefNamedPrivateNonFinalFieldWorker {
+  TestOptNullDefNamedPrivateNonFinalFieldWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestOptNullDefNamedPrivateNonFinalFieldWorker(
+      {int? state = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedPrivateNonFinalFieldWorker(
+            state: state,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedPrivateNonFinalFieldWorker.vm(
+      {int? state = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedPrivateNonFinalFieldWorker.vm(
+            state: state,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedPrivateNonFinalFieldWorker.js(
+      {int? state = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedPrivateNonFinalFieldWorker.js(
+            state: state,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestOptNullDefNamedPrivateNonFinalFieldWorker.wasm(
+      {int? state = 0,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestOptNullDefNamedPrivateNonFinalFieldWorker.wasm(
+            state: state,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  final _$TestOptNullDefNamedPrivateNonFinalFieldWorker _$worker;
+
+  static final Finalizer<_$TestOptNullDefNamedPrivateNonFinalFieldWorker>
+      _finalizer =
+      Finalizer<_$TestOptNullDefNamedPrivateNonFinalFieldWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<int?> getState() => _$worker.getState();
+
+  @override
+  Future<void> setState(int? state) => _$worker.setState(state);
+
+  @override
+  int? get _state => _$worker._state;
+
+  @override
+  set _state(void $value) => _$worker._state = $value;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -3508,31 +10741,31 @@ sq.WorkerService $TestInstallableInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestInstallable
-base class TestInstallableWorker extends sq.Worker
+base class _$TestInstallableWorker extends sq.Worker
     with _$TestInstallable$Invoker, _$TestInstallable$Facade
     implements TestInstallable {
-  TestInstallableWorker(int delay,
+  _$TestInstallableWorker(int delay,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [delay],
         super($TestInstallableActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestInstallableWorker.vm(int delay,
+  _$TestInstallableWorker.vm(int delay,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [delay],
         super($TestInstallableActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestInstallableWorker.js(int delay,
+  _$TestInstallableWorker.js(int delay,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [delay],
         super($TestInstallableActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestInstallableWorker.wasm(int delay,
+  _$TestInstallableWorker.wasm(int delay,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : _$startReq = [delay],
@@ -3543,14 +10776,149 @@ base class TestInstallableWorker extends sq.Worker
 
   @override
   List? getStartArgs() => _$startReq;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestInstallable
+base class TestInstallableWorker
+    with Releasable
+    implements _$TestInstallableWorker {
+  TestInstallableWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestInstallableWorker(int delay,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestInstallableWorker(delay,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestInstallableWorker.vm(int delay,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestInstallableWorker.vm(delay,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestInstallableWorker.js(int delay,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestInstallableWorker.js(delay,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestInstallableWorker.wasm(int delay,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestInstallableWorker.wasm(delay,
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$TestInstallableWorker _$worker;
+
+  static final Finalizer<_$TestInstallableWorker> _finalizer =
+      Finalizer<_$TestInstallableWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  FutureOr<void> install() => _$worker.install();
+
+  @override
+  FutureOr<void> uninstall() => _$worker.uninstall();
+
+  @override
+  int get _delay => _$worker._delay;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestInstallable
-base class TestInstallableWorkerPool
+base class _$TestInstallableWorkerPool
     extends sq.WorkerPool<TestInstallableWorker>
     with _$TestInstallable$Facade
     implements TestInstallable {
-  TestInstallableWorkerPool(int delay,
+  _$TestInstallableWorkerPool(int delay,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3562,7 +10930,7 @@ base class TestInstallableWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestInstallableWorkerPool.vm(int delay,
+  _$TestInstallableWorkerPool.vm(int delay,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3574,7 +10942,7 @@ base class TestInstallableWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestInstallableWorkerPool.js(int delay,
+  _$TestInstallableWorkerPool.js(int delay,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3586,7 +10954,7 @@ base class TestInstallableWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestInstallableWorkerPool.wasm(int delay,
+  _$TestInstallableWorkerPool.wasm(int delay,
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3596,6 +10964,168 @@ base class TestInstallableWorkerPool
                     threadHook: threadHook, exceptionManager: exceptionManager),
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestInstallable
+base class TestInstallableWorkerPool
+    with Releasable
+    implements _$TestInstallableWorkerPool {
+  TestInstallableWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestInstallableWorkerPool(int delay,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestInstallableWorkerPool(delay,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestInstallableWorkerPool.vm(int delay,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestInstallableWorkerPool.vm(delay,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestInstallableWorkerPool.js(int delay,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestInstallableWorkerPool.js(delay,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestInstallableWorkerPool.wasm(int delay,
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestInstallableWorkerPool.wasm(delay,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestInstallableWorkerPool _$pool;
+
+  static final Finalizer<_$TestInstallableWorkerPool> _finalizer =
+      Finalizer<_$TestInstallableWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  FutureOr<void> install() => _$pool.install();
+
+  @override
+  FutureOr<void> uninstall() => _$pool.uninstall();
+
+  @override
+  int get _delay => _$pool._delay;
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestInstallableWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(TestInstallableWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(TestInstallableWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestInstallableWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestInstallableWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -3704,28 +11234,28 @@ sq.WorkerService $TestRecordTypesInitializer(sq.WorkerRequest $req) =>
     _$TestRecordTypes$WorkerService();
 
 /// Worker for TestRecordTypes
-base class TestRecordTypesWorker extends sq.Worker
+base class _$TestRecordTypesWorker extends sq.Worker
     with _$TestRecordTypes$Invoker, _$TestRecordTypes$Facade
     implements TestRecordTypes {
-  TestRecordTypesWorker(
+  _$TestRecordTypesWorker(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestRecordTypesActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestRecordTypesWorker.vm(
+  _$TestRecordTypesWorker.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestRecordTypesActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestRecordTypesWorker.js(
+  _$TestRecordTypesWorker.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestRecordTypesActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestRecordTypesWorker.wasm(
+  _$TestRecordTypesWorker.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestRecordTypesActivator(sq.SquadronPlatformType.wasm),
@@ -3733,14 +11263,151 @@ base class TestRecordTypesWorker extends sq.Worker
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestRecordTypes
+base class TestRecordTypesWorker
+    with Releasable
+    implements _$TestRecordTypesWorker {
+  TestRecordTypesWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestRecordTypesWorker(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestRecordTypesWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestRecordTypesWorker.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestRecordTypesWorker.vm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestRecordTypesWorker.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestRecordTypesWorker.js(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestRecordTypesWorker.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestRecordTypesWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$TestRecordTypesWorker _$worker;
+
+  static final Finalizer<_$TestRecordTypesWorker> _finalizer =
+      Finalizer<_$TestRecordTypesWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<(int, {List<int> items})> both() => _$worker.both();
+
+  @override
+  Future<bool> input((int, {List<int> items}) both, (int, List<dynamic>) pos,
+          ({int count, List<dynamic> items}) named) =>
+      _$worker.input(both, pos, named);
+
+  @override
+  Future<({int count, List<dynamic> items})> named() => _$worker.named();
+
+  @override
+  Future<(int, List<dynamic>)> unnamed() => _$worker.unnamed();
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestRecordTypes
-base class TestRecordTypesWorkerPool
+base class _$TestRecordTypesWorkerPool
     extends sq.WorkerPool<TestRecordTypesWorker>
     with _$TestRecordTypes$Facade
     implements TestRecordTypes {
-  TestRecordTypesWorkerPool(
+  _$TestRecordTypesWorkerPool(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3750,7 +11417,7 @@ base class TestRecordTypesWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestRecordTypesWorkerPool.vm(
+  _$TestRecordTypesWorkerPool.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3760,7 +11427,7 @@ base class TestRecordTypesWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestRecordTypesWorkerPool.js(
+  _$TestRecordTypesWorkerPool.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3770,7 +11437,7 @@ base class TestRecordTypesWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestRecordTypesWorkerPool.wasm(
+  _$TestRecordTypesWorkerPool.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -3795,6 +11462,173 @@ base class TestRecordTypesWorkerPool
 
   @override
   Future<(int, List<dynamic>)> unnamed() => execute((w) => w.unnamed());
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestRecordTypes
+base class TestRecordTypesWorkerPool
+    with Releasable
+    implements _$TestRecordTypesWorkerPool {
+  TestRecordTypesWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestRecordTypesWorkerPool(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestRecordTypesWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestRecordTypesWorkerPool.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestRecordTypesWorkerPool.vm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestRecordTypesWorkerPool.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestRecordTypesWorkerPool.js(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestRecordTypesWorkerPool.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestRecordTypesWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestRecordTypesWorkerPool _$pool;
+
+  static final Finalizer<_$TestRecordTypesWorkerPool> _finalizer =
+      Finalizer<_$TestRecordTypesWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<(int, {List<int> items})> both() => _$pool.both();
+
+  @override
+  Future<bool> input((int, {List<int> items}) both, (int, List<dynamic>) pos,
+          ({int count, List<dynamic> items}) named) =>
+      _$pool.input(both, pos, named);
+
+  @override
+  Future<({int count, List<dynamic> items})> named() => _$pool.named();
+
+  @override
+  Future<(int, List<dynamic>)> unnamed() => _$pool.unnamed();
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestRecordTypesWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(TestRecordTypesWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(TestRecordTypesWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestRecordTypesWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestRecordTypesWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -3835,10 +11669,10 @@ sq.WorkerService $TestRequiredSuperParamInitializer(sq.WorkerRequest $req) {
 }
 
 /// Worker for TestRequiredSuperParam
-base class TestRequiredSuperParamWorker extends sq.Worker
+base class _$TestRequiredSuperParamWorker extends sq.Worker
     with _$TestRequiredSuperParam$Invoker, _$TestRequiredSuperParam$Facade
     implements TestRequiredSuperParam {
-  TestRequiredSuperParamWorker(
+  _$TestRequiredSuperParamWorker(
       {required this.path,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3846,7 +11680,7 @@ base class TestRequiredSuperParamWorker extends sq.Worker
         super($TestRequiredSuperParamActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestRequiredSuperParamWorker.vm(
+  _$TestRequiredSuperParamWorker.vm(
       {required this.path,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3854,7 +11688,7 @@ base class TestRequiredSuperParamWorker extends sq.Worker
         super($TestRequiredSuperParamActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestRequiredSuperParamWorker.js(
+  _$TestRequiredSuperParamWorker.js(
       {required this.path,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3862,7 +11696,7 @@ base class TestRequiredSuperParamWorker extends sq.Worker
         super($TestRequiredSuperParamActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestRequiredSuperParamWorker.wasm(
+  _$TestRequiredSuperParamWorker.wasm(
       {required this.path,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
@@ -3877,14 +11711,158 @@ base class TestRequiredSuperParamWorker extends sq.Worker
 
   @override
   final String path;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestRequiredSuperParam
+base class TestRequiredSuperParamWorker
+    with Releasable
+    implements _$TestRequiredSuperParamWorker {
+  TestRequiredSuperParamWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestRequiredSuperParamWorker(
+      {required String path,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestRequiredSuperParamWorker(
+            path: path,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestRequiredSuperParamWorker.vm(
+      {required String path,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestRequiredSuperParamWorker.vm(
+            path: path,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestRequiredSuperParamWorker.js(
+      {required String path,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestRequiredSuperParamWorker.js(
+            path: path,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  TestRequiredSuperParamWorker.wasm(
+      {required String path,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestRequiredSuperParamWorker.wasm(
+            path: path,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager));
+
+  @override
+  String get path => _$worker.path;
+
+  final _$TestRequiredSuperParamWorker _$worker;
+
+  static final Finalizer<_$TestRequiredSuperParamWorker> _finalizer =
+      Finalizer<_$TestRequiredSuperParamWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List<dynamic> get _$startReq => const [];
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<void> clear() => _$worker.clear();
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestRequiredSuperParam
-base class TestRequiredSuperParamWorkerPool
+base class _$TestRequiredSuperParamWorkerPool
     extends sq.WorkerPool<TestRequiredSuperParamWorker>
     with _$TestRequiredSuperParam$Facade
     implements TestRequiredSuperParam {
-  TestRequiredSuperParamWorkerPool(
+  _$TestRequiredSuperParamWorkerPool(
       {required this.path,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -3898,7 +11876,7 @@ base class TestRequiredSuperParamWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestRequiredSuperParamWorkerPool.vm(
+  _$TestRequiredSuperParamWorkerPool.vm(
       {required this.path,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -3912,7 +11890,7 @@ base class TestRequiredSuperParamWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestRequiredSuperParamWorkerPool.js(
+  _$TestRequiredSuperParamWorkerPool.js(
       {required this.path,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -3926,7 +11904,7 @@ base class TestRequiredSuperParamWorkerPool
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestRequiredSuperParamWorkerPool.wasm(
+  _$TestRequiredSuperParamWorkerPool.wasm(
       {required this.path,
       sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
@@ -3945,6 +11923,175 @@ base class TestRequiredSuperParamWorkerPool
 
   @override
   Future<void> clear() => execute((w) => w.clear());
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestRequiredSuperParam
+base class TestRequiredSuperParamWorkerPool
+    with Releasable
+    implements _$TestRequiredSuperParamWorkerPool {
+  TestRequiredSuperParamWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestRequiredSuperParamWorkerPool(
+      {required String path,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestRequiredSuperParamWorkerPool(
+            path: path,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestRequiredSuperParamWorkerPool.vm(
+      {required String path,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestRequiredSuperParamWorkerPool.vm(
+            path: path,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestRequiredSuperParamWorkerPool.js(
+      {required String path,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestRequiredSuperParamWorkerPool.js(
+            path: path,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestRequiredSuperParamWorkerPool.wasm(
+      {required String path,
+      sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestRequiredSuperParamWorkerPool.wasm(
+            path: path,
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  @override
+  String get path => _$pool.path;
+
+  final _$TestRequiredSuperParamWorkerPool _$pool;
+
+  static final Finalizer<_$TestRequiredSuperParamWorkerPool> _finalizer =
+      Finalizer<_$TestRequiredSuperParamWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<void> clear() => _$pool.clear();
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestRequiredSuperParamWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(
+          Future<T> Function(TestRequiredSuperParamWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(
+          Stream<T> Function(TestRequiredSuperParamWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestRequiredSuperParamWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestRequiredSuperParamWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -3995,28 +12142,28 @@ sq.WorkerService $TestBigIntInitializer(sq.WorkerRequest $req) =>
     _$TestBigInt$WorkerService();
 
 /// Worker for TestBigInt
-base class TestBigIntWorker extends sq.Worker
+base class _$TestBigIntWorker extends sq.Worker
     with _$TestBigInt$Invoker, _$TestBigInt$Facade
     implements TestBigInt {
-  TestBigIntWorker(
+  _$TestBigIntWorker(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestBigIntActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestBigIntWorker.vm(
+  _$TestBigIntWorker.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestBigIntActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestBigIntWorker.js(
+  _$TestBigIntWorker.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestBigIntActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestBigIntWorker.wasm(
+  _$TestBigIntWorker.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestBigIntActivator(sq.SquadronPlatformType.wasm),
@@ -4024,13 +12171,137 @@ base class TestBigIntWorker extends sq.Worker
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestBigInt
+base class TestBigIntWorker with Releasable implements _$TestBigIntWorker {
+  TestBigIntWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestBigIntWorker(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestBigIntWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestBigIntWorker.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestBigIntWorker.vm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestBigIntWorker.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestBigIntWorker.js(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestBigIntWorker.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestBigIntWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$TestBigIntWorker _$worker;
+
+  static final Finalizer<_$TestBigIntWorker> _finalizer =
+      Finalizer<_$TestBigIntWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<BigInt> add(BigInt a, BigInt b) => _$worker.add(a, b);
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestBigInt
-base class TestBigIntWorkerPool extends sq.WorkerPool<TestBigIntWorker>
+base class _$TestBigIntWorkerPool extends sq.WorkerPool<TestBigIntWorker>
     with _$TestBigInt$Facade
     implements TestBigInt {
-  TestBigIntWorkerPool(
+  _$TestBigIntWorkerPool(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -4040,7 +12311,7 @@ base class TestBigIntWorkerPool extends sq.WorkerPool<TestBigIntWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestBigIntWorkerPool.vm(
+  _$TestBigIntWorkerPool.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -4050,7 +12321,7 @@ base class TestBigIntWorkerPool extends sq.WorkerPool<TestBigIntWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestBigIntWorkerPool.js(
+  _$TestBigIntWorkerPool.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -4060,7 +12331,7 @@ base class TestBigIntWorkerPool extends sq.WorkerPool<TestBigIntWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestBigIntWorkerPool.wasm(
+  _$TestBigIntWorkerPool.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -4072,6 +12343,162 @@ base class TestBigIntWorkerPool extends sq.WorkerPool<TestBigIntWorker>
 
   @override
   Future<BigInt> add(BigInt a, BigInt b) => execute((w) => w.add(a, b));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestBigInt
+base class TestBigIntWorkerPool
+    with Releasable
+    implements _$TestBigIntWorkerPool {
+  TestBigIntWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestBigIntWorkerPool(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestBigIntWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestBigIntWorkerPool.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestBigIntWorkerPool.vm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestBigIntWorkerPool.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestBigIntWorkerPool.js(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestBigIntWorkerPool.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestBigIntWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestBigIntWorkerPool _$pool;
+
+  static final Finalizer<_$TestBigIntWorkerPool> _finalizer =
+      Finalizer<_$TestBigIntWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<BigInt> add(BigInt a, BigInt b) => _$pool.add(a, b);
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestBigIntWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(TestBigIntWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(TestBigIntWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestBigIntWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestBigIntWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Command ids used in operations map
@@ -4154,28 +12581,28 @@ sq.WorkerService $TestCustomDataInitializer(sq.WorkerRequest $req) =>
     _$TestCustomData$WorkerService();
 
 /// Worker for TestCustomData
-base class TestCustomDataWorker extends sq.Worker
+base class _$TestCustomDataWorker extends sq.Worker
     with _$TestCustomData$Invoker, _$TestCustomData$Facade
     implements TestCustomData {
-  TestCustomDataWorker(
+  _$TestCustomDataWorker(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestCustomDataActivator(sq.Squadron.platformType),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestCustomDataWorker.vm(
+  _$TestCustomDataWorker.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestCustomDataActivator(sq.SquadronPlatformType.vm),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestCustomDataWorker.js(
+  _$TestCustomDataWorker.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestCustomDataActivator(sq.SquadronPlatformType.js),
             threadHook: threadHook, exceptionManager: exceptionManager);
 
-  TestCustomDataWorker.wasm(
+  _$TestCustomDataWorker.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager})
       : super($TestCustomDataActivator(sq.SquadronPlatformType.wasm),
@@ -4183,13 +12610,143 @@ base class TestCustomDataWorker extends sq.Worker
 
   @override
   List? getStartArgs() => null;
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker wrapper for TestCustomData
+base class TestCustomDataWorker
+    with Releasable
+    implements _$TestCustomDataWorker {
+  TestCustomDataWorker._(this._$worker) {
+    _finalizer.attach(this, _$worker, detach: _$worker._$detachToken);
+  }
+
+  TestCustomDataWorker(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestCustomDataWorker(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestCustomDataWorker.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestCustomDataWorker.vm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestCustomDataWorker.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestCustomDataWorker.js(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  TestCustomDataWorker.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager})
+      : this._(_$TestCustomDataWorker.wasm(
+            threadHook: threadHook, exceptionManager: exceptionManager));
+
+  final _$TestCustomDataWorker _$worker;
+
+  static final Finalizer<_$TestCustomDataWorker> _finalizer =
+      Finalizer<_$TestCustomDataWorker>((w) {
+    try {
+      _finalizer.detach(w._$detachToken);
+      w.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$worker.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  List? getStartArgs() => null;
+
+  @override
+  Future<List<CustomData>> many(List<CustomData> data) => _$worker.many(data);
+
+  @override
+  Future<CustomData> one(CustomData data) => _$worker.one(data);
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$worker.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$worker.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$worker.channelLogger = value;
+
+  @override
+  bool get isConnected => _$worker.isConnected;
+
+  @override
+  bool get isStopped => _$worker.isStopped;
+
+  @override
+  sq.WorkerStat get stats => _$worker.stats;
+
+  @override
+  sq.WorkerStat getStats() => _$worker.getStats();
+
+  @override
+  Future<sq.Channel> start() => _$worker.start();
+
+  @override
+  void stop() => _$worker.stop();
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$worker.terminate(ex);
+
+  @override
+  sq.Channel? getSharedChannel() => _$worker.getSharedChannel();
+
+  @override
+  Future<dynamic> send(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.send(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Stream<dynamic> stream(int command,
+          {List args = const [],
+          CancelationToken? token,
+          bool inspectRequest = false,
+          bool inspectResponse = false}) =>
+      _$worker.stream(command,
+          args: args,
+          token: token,
+          inspectRequest: inspectRequest,
+          inspectResponse: inspectResponse);
+
+  @override
+  Object get _$detachToken => _$worker._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 /// Worker pool for TestCustomData
-base class TestCustomDataWorkerPool extends sq.WorkerPool<TestCustomDataWorker>
+base class _$TestCustomDataWorkerPool
+    extends sq.WorkerPool<TestCustomDataWorker>
     with _$TestCustomData$Facade
     implements TestCustomData {
-  TestCustomDataWorkerPool(
+  _$TestCustomDataWorkerPool(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -4199,7 +12756,7 @@ base class TestCustomDataWorkerPool extends sq.WorkerPool<TestCustomDataWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestCustomDataWorkerPool.vm(
+  _$TestCustomDataWorkerPool.vm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -4209,7 +12766,7 @@ base class TestCustomDataWorkerPool extends sq.WorkerPool<TestCustomDataWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestCustomDataWorkerPool.js(
+  _$TestCustomDataWorkerPool.js(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -4219,7 +12776,7 @@ base class TestCustomDataWorkerPool extends sq.WorkerPool<TestCustomDataWorker>
             concurrencySettings: concurrencySettings,
             exceptionManager: exceptionManager);
 
-  TestCustomDataWorkerPool.wasm(
+  _$TestCustomDataWorkerPool.wasm(
       {sq.PlatformThreadHook? threadHook,
       sq.ExceptionManager? exceptionManager,
       sq.ConcurrencySettings? concurrencySettings})
@@ -4235,6 +12792,165 @@ base class TestCustomDataWorkerPool extends sq.WorkerPool<TestCustomDataWorker>
 
   @override
   Future<CustomData> one(CustomData data) => execute((w) => w.one(data));
+
+  final _$detachToken = Object();
+}
+
+/// Finalizable worker pool wrapper for TestCustomData
+base class TestCustomDataWorkerPool
+    with Releasable
+    implements _$TestCustomDataWorkerPool {
+  TestCustomDataWorkerPool._(this._$pool) {
+    _finalizer.attach(this, _$pool, detach: _$pool._$detachToken);
+  }
+
+  TestCustomDataWorkerPool(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestCustomDataWorkerPool(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestCustomDataWorkerPool.vm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestCustomDataWorkerPool.vm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestCustomDataWorkerPool.js(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestCustomDataWorkerPool.js(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  TestCustomDataWorkerPool.wasm(
+      {sq.PlatformThreadHook? threadHook,
+      sq.ExceptionManager? exceptionManager,
+      sq.ConcurrencySettings? concurrencySettings})
+      : this._(_$TestCustomDataWorkerPool.wasm(
+            threadHook: threadHook,
+            exceptionManager: exceptionManager,
+            concurrencySettings: concurrencySettings));
+
+  final _$TestCustomDataWorkerPool _$pool;
+
+  static final Finalizer<_$TestCustomDataWorkerPool> _finalizer =
+      Finalizer<_$TestCustomDataWorkerPool>((p) {
+    try {
+      _finalizer.detach(p._$detachToken);
+      p.release();
+    } catch (_) {
+      // finalizers must not throw
+    }
+  });
+
+  @override
+  void release() {
+    try {
+      _$pool.release();
+      super.release();
+    } catch (_) {
+      // release should not throw
+    }
+  }
+
+  @override
+  Future<List<CustomData>> many(List<CustomData> data) => _$pool.many(data);
+
+  @override
+  Future<CustomData> one(CustomData data) => _$pool.one(data);
+
+  @override
+  sq.ExceptionManager get exceptionManager => _$pool.exceptionManager;
+
+  @override
+  Logger? get channelLogger => _$pool.channelLogger;
+
+  @override
+  set channelLogger(Logger? value) => _$pool.channelLogger = value;
+
+  @override
+  sq.ConcurrencySettings get concurrencySettings => _$pool.concurrencySettings;
+
+  @override
+  Iterable<sq.WorkerStat> get fullStats => _$pool.fullStats;
+
+  @override
+  int get pendingWorkload => _$pool.pendingWorkload;
+
+  @override
+  int get maxSize => _$pool.maxSize;
+
+  @override
+  int get size => _$pool.size;
+
+  @override
+  Iterable<sq.WorkerStat> get stats => _$pool.stats;
+
+  @override
+  bool get stopped => _$pool.stopped;
+
+  @override
+  void cancelAll([String? message]) => _$pool.cancelAll(message);
+
+  @override
+  void cancel(sq.Task task, [String? message]) => _$pool.cancel(task, message);
+
+  @override
+  FutureOr<void> start() => _$pool.start();
+
+  @override
+  int stop([bool Function(TestCustomDataWorker worker)? predicate]) =>
+      _$pool.stop(predicate);
+
+  @override
+  void terminate([sq.TaskTerminatedException? ex]) => _$pool.terminate(ex);
+
+  @override
+  Object registerWorkerPoolListener(
+          void Function(sq.WorkerStat, bool) listener) =>
+      _$pool.registerWorkerPoolListener(listener);
+
+  @override
+  void unregisterWorkerPoolListener(
+          {void Function(sq.WorkerStat, bool)? listener, Object? token}) =>
+      _$pool.unregisterWorkerPoolListener(listener: listener, token: token);
+
+  @override
+  Future<T> execute<T>(Future<T> Function(TestCustomDataWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.execute<T>(task, counter: counter);
+
+  @override
+  Stream<T> stream<T>(Stream<T> Function(TestCustomDataWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.stream<T>(task, counter: counter);
+
+  @override
+  sq.StreamTask<T> scheduleStreamTask<T>(
+          Stream<T> Function(TestCustomDataWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleStreamTask<T>(task, counter: counter);
+
+  @override
+  sq.ValueTask<T> scheduleValueTask<T>(
+          Future<T> Function(TestCustomDataWorker worker) task,
+          {sq.PerfCounter? counter}) =>
+      _$pool.scheduleValueTask<T>(task, counter: counter);
+
+  @override
+  Object get _$detachToken => _$pool._$detachToken;
+
+  @override
+  final sq.OperationsMap operations = sq.WorkerService.noOperations;
 }
 
 final class _$Deser extends sq.MarshalingContext {

--- a/example/test/generated/test_services.worker.g.dart
+++ b/example/test/generated/test_services.worker.g.dart
@@ -4,7 +4,7 @@
 part of '../test_services.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.4 (Squadron 7.1.1)
+// Generator: WorkerGenerator 7.1.5-mki (Squadron 7.1.2)
 // **************************************************************************
 
 /// Command ids used in operations map

--- a/lib/src/_analyzer_helpers.dart
+++ b/lib/src/_analyzer_helpers.dart
@@ -4,7 +4,7 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element2.dart' as element_;
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:analyzer/dart/element/visitor.dart' as visitor_;
+import 'package:analyzer/dart/element/visitor2.dart' as visitor_;
 import 'package:meta/meta.dart';
 import 'package:squadron_builder/src/types/type_manager.dart';
 
@@ -32,7 +32,7 @@ typedef ConstructorElement = element_.ConstructorElement2;
 typedef InterfaceElement = element_.InterfaceElement2;
 typedef TypeParameterElement = element_.TypeParameterElement2;
 
-typedef SimpleElementVisitor<T> = visitor_.SimpleElementVisitor<T>;
+typedef SimpleElementVisitor<T> = visitor_.GeneralizingElementVisitor2<T>;
 
 @internal
 extension ElementExt on Element {

--- a/lib/src/assets/helpers/worker_assets_overrides.dart
+++ b/lib/src/assets/helpers/worker_assets_overrides.dart
@@ -11,7 +11,9 @@ extension SquadronOverrides on WorkerAssets {
       '$TLogger? get channelLogger': 'channelLogger',
       'set channelLogger($TLogger? value)': 'channelLogger = value',
       '$TBool get isConnected': 'isConnected',
+      '$TBool get isStopped': 'isStopped',
       '$TWorkerStat get stats': 'stats',
+      '$TWorkerStat getStats()': 'getStats()',
       // worker control
       '$TFuture<$TChannel> start()': 'start()',
       'void stop()': 'stop()',

--- a/lib/src/build_step_events.dart
+++ b/lib/src/build_step_events.dart
@@ -1,3 +1,4 @@
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -168,7 +169,7 @@ class BuildStepCodeEvent extends BuildStepEvent {
 /// Code event emitted when a library has been fully processed
 @internal
 class BuildStepDoneEvent extends BuildStepEvent {
-  BuildStepDoneEvent(super.buildStep, LibraryElement lib)
+  BuildStepDoneEvent(super.buildStep, LibraryElement2 lib)
       : languageVersion = lib.languageVersion.package;
 
   final Version languageVersion;

--- a/lib/src/build_step_events.dart
+++ b/lib/src/build_step_events.dart
@@ -1,4 +1,3 @@
-import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -169,7 +168,7 @@ class BuildStepCodeEvent extends BuildStepEvent {
 /// Code event emitted when a library has been fully processed
 @internal
 class BuildStepDoneEvent extends BuildStepEvent {
-  BuildStepDoneEvent(super.buildStep, LibraryElement2 lib)
+  BuildStepDoneEvent(super.buildStep, LibraryElement lib)
       : languageVersion = lib.languageVersion.package;
 
   final Version languageVersion;

--- a/lib/src/marshalers/marshaler_explicit.dart
+++ b/lib/src/marshalers/marshaler_explicit.dart
@@ -6,11 +6,12 @@ class _ExplicitMarshaler extends Marshaler {
       : _itemType = marshalerType.typeArguments.first,
         _pivotType = marshalerType.typeArguments.last {
     // ignore: deprecated_member_use
-    final variable = _marshaler.variable;
-    if (variable != null) {
+    final variable = _marshaler.variable2;
+    final name = variable?.name3;
+    if (variable != null && name != null) {
       _instance = switch (variable.enclosingElt) {
-        InterfaceElement enclosing => '${enclosing.name}.${variable.name}',
-        _ => variable.name,
+        (final enclosing) when enclosing is InterfaceElement && enclosing.name3 != null => '${enclosing.name3!}.$name',
+        _ => name,
       };
     } else {
       final typeName = typeManager

--- a/lib/src/marshalers/marshaler_self.dart
+++ b/lib/src/marshalers/marshaler_self.dart
@@ -12,7 +12,7 @@ class _SelfMarshaler extends Marshaler {
         contextIn = _getContextArg(unmarshalingContext);
 
   static String _getContextArg(ParameterElement? ctx) =>
-      (ctx == null) ? '' : (ctx.isNamed ? '${ctx.name}: this' : 'this');
+      (ctx == null || ctx.name3 == null) ? '' : (ctx.isNamed ? '${ctx.name3!}: this' : 'this');
 
   final String typeName;
   final String loaderTypeName;

--- a/lib/src/readers/dart_method_reader.dart
+++ b/lib/src/readers/dart_method_reader.dart
@@ -18,7 +18,8 @@ part 'squadron_method_reader.dart';
 /// Reader for non-service methods implemented in a SquadronService
 class DartMethodReader {
   DartMethodReader._(MethodElement method, this.typeManager, this.context)
-      : name = method.name,
+      : assert(method.name3 != null, "Method name can't be null"),
+        name = method.name3!,
         returnType = typeManager.handleDartType(method.returnType),
         parameters = SquadronParameters(typeManager);
 
@@ -48,18 +49,18 @@ class DartMethodReader {
 
   void _init(MethodElement method) {
     method.typeParams.map((e) => e.toString()).forEach(typeParameters.add);
-    method.parameters.forEach(parameters.register);
+    method.formalParameters.forEach(parameters.register);
   }
 
   static DartMethodReader? load(MethodElement method, TypeManager typeManager,
       MarshalingContext context) {
-    if (method.name == 'toString' || method.name == 'noSuchMethod') {
+    if (method.name3 == 'toString' || method.name3 == 'noSuchMethod') {
       // base Dart methods -- ignore
       return null;
     }
     final reader = AnnotationReader<squadron.SquadronMethod>.single(method);
     DartMethodReader m;
-    if (reader.isEmpty || method.name.startsWith('_')) {
+    if (reader.isEmpty || (method.name3?.startsWith('_') ?? false)) {
       // private method or no SquadronMethod annotation
       m = DartMethodReader._(method, typeManager, context);
     } else {

--- a/lib/src/readers/squadron_method_reader.dart
+++ b/lib/src/readers/squadron_method_reader.dart
@@ -9,7 +9,8 @@ class SquadronMethodReader extends DartMethodReader {
       this.withContext,
       TypeManager typeManager,
       MarshalingContext context)
-      : id = '_\$${method.name}Id',
+      : assert(method.name3 != null, "Method name can't be null"),
+        id = '_\$${method.name3}Id',
         patchedReturnType = _patchReturnType(method, typeManager),
         resultMarshaler = typeManager.getExplicitMarshaler(method),
         super._(method, typeManager, context);
@@ -19,8 +20,7 @@ class SquadronMethodReader extends DartMethodReader {
     var returnType = method.returnType;
     if (method.returnType.isDartAsyncFutureOr) {
       final valueType = (returnType as ParameterizedType).typeArguments.single;
-      // ignore: deprecated_member_use
-      returnType = method.library.typeProvider.futureType(valueType);
+      returnType = method.library2.typeProvider.futureType(valueType);
     }
     return typeManager.handleDartType(returnType);
   }
@@ -55,15 +55,15 @@ class SquadronMethodReader extends DartMethodReader {
     final type = patchedReturnType.dartType!;
     if (!type.isDartAsyncFuture && !type.isDartAsyncStream) {
       throw InvalidGenerationSourceError(
-          '${method.librarySource.fullName}: public service method '
-          '\'${method.enclosingElt?.displayName}.${method.name}\' must '
+          '${method.library2.name3}: public service method '
+          '\'${method.enclosingElt?.displayName}.${method.name3}\' must '
           'return a Future, a FutureOr, a Stream, or void.');
     }
 
     typeParameters.addAll(method.typeParams.map((e) => e.toString()));
 
-    for (var n = 0; n < method.parameters.length; n++) {
-      final param = method.parameters[n];
+    for (var n = 0; n < method.formalParameters.length; n++) {
+      final param = method.formalParameters[n];
       parameters.register(param, typeManager.getExplicitMarshaler(param));
     }
   }

--- a/lib/src/readers/squadron_parameter.dart
+++ b/lib/src/readers/squadron_parameter.dart
@@ -27,16 +27,16 @@ class SquadronParameter {
 
   static SquadronParameter from(ParameterElement param, bool isToken,
       Marshaler? marshaler, int serIdx, TypeManager typeManager) {
-    var name = param.name;
+    var name = param.name3 ?? '';
     var type = param.type;
     FieldElement? field;
     if (param is FieldFormalParameterElement) {
       // ignore: deprecated_member_use
-      final fld = param.field;
+      final fld = param.field2;
       if (fld != null) {
         field = fld;
         type = field.type;
-        name = field.name;
+        name = field.name3 ?? '';
         while (name.startsWith('_')) {
           name = name.substring((1));
         }
@@ -76,7 +76,7 @@ class SquadronParameter {
   bool get mayBeNull =>
       (isOptional || (isNamed && required.isEmpty)) && defaultValue == null;
 
-  bool get isPublicField => field != null && !field!.name.startsWith('_');
+  bool get isPublicField => field != null && !(field!.name3?.startsWith('_') ?? false);
 
   String argument() => isNamed ? '$name: $name' : name;
 

--- a/lib/src/readers/squadron_parameter.dart
+++ b/lib/src/readers/squadron_parameter.dart
@@ -1,3 +1,4 @@
+import 'package:source_gen/source_gen.dart';
 import 'package:squadron/squadron.dart' as squadron;
 
 import '../_analyzer_helpers.dart';
@@ -27,7 +28,13 @@ class SquadronParameter {
 
   static SquadronParameter from(ParameterElement param, bool isToken,
       Marshaler? marshaler, int serIdx, TypeManager typeManager) {
-    var name = param.name3 ?? '';
+    var name = param.name3;
+
+    if (name == null) {
+      throw InvalidGenerationSourceError('Parameter name cannot be null '
+          'for ${param.enclosingElement2?.name3}.');
+    }
+
     var type = param.type;
     FieldElement? field;
     if (param is FieldFormalParameterElement) {
@@ -36,8 +43,14 @@ class SquadronParameter {
       if (fld != null) {
         field = fld;
         type = field.type;
-        name = field.name3 ?? '';
-        while (name.startsWith('_')) {
+        name = field.name3;
+
+        if (name == null) {
+          throw InvalidGenerationSourceError('Parameter name cannot be null '
+              'for ${field.enclosingElement2.name3}.');
+        }
+
+        while (name!.startsWith('_')) {
           name = name.substring((1));
         }
       }
@@ -76,7 +89,8 @@ class SquadronParameter {
   bool get mayBeNull =>
       (isOptional || (isNamed && required.isEmpty)) && defaultValue == null;
 
-  bool get isPublicField => field != null && !(field!.name3?.startsWith('_') ?? false);
+  bool get isPublicField =>
+      field != null && field!.name3 != null && !field!.name3!.startsWith('_');
 
   String argument() => isNamed ? '$name: $name' : name;
 

--- a/lib/src/readers/squadron_parameters.dart
+++ b/lib/src/readers/squadron_parameters.dart
@@ -58,10 +58,10 @@ class SquadronParameters {
     if (_cancelationToken != null) {
       throw InvalidGenerationSourceError(
           'Multiple cancelation tokens may not be passed to service methods '
-          '($_cancelationToken, ${param.name}). You should use a '
+          '($_cancelationToken, ${param.name3}). You should use a '
           'CompositeCancelationToken instead.');
     } else {
-      _cancelationToken = param.name;
+      _cancelationToken = param.name3;
       return true;
     }
   }

--- a/lib/src/readers/squadron_service_reader.dart
+++ b/lib/src/readers/squadron_service_reader.dart
@@ -1,4 +1,3 @@
-import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:squadron/squadron.dart' as squadron;
@@ -97,7 +96,7 @@ class SquadronServiceReader {
   }
 
   static SquadronServiceReader? load(
-      ClassElement2 clazz, GeneratorContext context) {
+      ClassElement clazz, GeneratorContext context) {
     final reader = AnnotationReader<squadron.SquadronService>(clazz);
     if (reader.isEmpty) return null;
 

--- a/lib/src/readers/squadron_service_reader.dart
+++ b/lib/src/readers/squadron_service_reader.dart
@@ -59,11 +59,9 @@ class SquadronServiceReader {
           'Worker service classes must be constructable.');
     }
 
-    // ignore: deprecated_member_use
     final ctorElement = clazz.unnamedConstructor2;
 
     if (ctorElement == null) {
-      // ignore: deprecated_member_use
       if (clazz.constructors2.isNotEmpty) {
         log.warning('Missing unnamed constructor for ${clazz.name3}');
       }
@@ -72,7 +70,6 @@ class SquadronServiceReader {
         final param = ctorElement.formalParameters[n];
 
         if (param is FieldFormalParameterElement) {
-          // ignore: deprecated_member_use
           final fld = param.field2;
           if (fld != null) {
             final name = fld.name3;
@@ -95,18 +92,8 @@ class SquadronServiceReader {
     }
 
     methods.addAll(clazz.methods2.where((m) => !m.isStatic));
-    final fragments = clazz.fragments;
-    for (final fragment in fragments) {
-      final getters = fragment.getters
-          .where((b) => !fragment.fields2.map((c) => c.name2).contains(b.name2))
-          .map((e) => e.element as PropertyAccessorElement2);
-      final setters = fragment.setters
-          .where((b) => !fragment.fields2
-              .map((c) => c.name2?.replaceAll('=', ''))
-              .contains(b.name2))
-          .map((e) => e.element as PropertyAccessorElement2);
-      accessors.addAll(getters.followedBy(setters));
-    }
+    accessors.addAll(clazz.getters2.where((a) => !a.isStatic && !fields.containsKey(a.property)));
+    accessors.addAll(clazz.setters2.where((a) => !a.isStatic && !fields.containsKey(a.property)));
   }
 
   static SquadronServiceReader? load(

--- a/lib/src/types/managed_type.dart
+++ b/lib/src/types/managed_type.dart
@@ -2,7 +2,6 @@ import 'dart:collection';
 
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:analyzer/dart/element/visitor2.dart';
 
 import '../_analyzer_helpers.dart';
 import '../_helpers.dart';

--- a/lib/src/types/managed_type.dart
+++ b/lib/src/types/managed_type.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/dart/element/visitor2.dart';
 
 import '../_analyzer_helpers.dart';
 import '../_helpers.dart';
@@ -103,7 +104,7 @@ abstract class ManagedType with ManagedTypeMixin {
         return '${px}dynamic';
       }
       final a = typeArguments.isEmpty ? '' : '<${typeArguments.join(', ')}>';
-      return '$px${dartType!.elt!.name}$a${nullabilitySuffix.suffix}';
+      return '$px${dartType!.elt!.name3!}$a${nullabilitySuffix.suffix}';
     } catch (ex) {
       throw Exception(
           'Error for dartType = $dartType / element = ${dartType?.elt}');

--- a/lib/src/types/marshaler_inspector.dart
+++ b/lib/src/types/marshaler_inspector.dart
@@ -1,6 +1,6 @@
 part of 'managed_type.dart';
 
-class MarshalerInspector extends GeneralizingElementVisitor2 {
+class MarshalerInspector extends SimpleElementVisitor {
   MarshalerInspector(this.typeManager);
 
   final TypeManager typeManager;

--- a/lib/src/types/type_manager.dart
+++ b/lib/src/types/type_manager.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -13,7 +14,7 @@ class TypeManager with _ImportedTypesMixin {
   TypeManager(this.library)
       : dartCoreAlias = library.getPrefixFor(PckUri.dartCore) ?? '';
 
-  final LibraryElement library;
+  final LibraryElement2 library;
   final String dartCoreAlias;
   late final String squadronAlias;
 
@@ -50,15 +51,15 @@ class TypeManager with _ImportedTypesMixin {
     final lib = switch (element) {
       LibraryElement() => element,
       // ignore: deprecated_member_use
-      Element() => element.library,
+      Element() => element.library2,
       null => null,
     };
     if (lib == null) return '';
     // ignore: deprecated_member_use
-    return library.definingCompilationUnit.libraryImportPrefixes
-            .where((p) => p.imports.any((i) => i.importedLibrary == lib))
+    return library.firstFragment.libraryImports2
+            .where((p) => p.importedLibrary2 == lib)
             .firstOrNull
-            ?.name ??
+            ?.libraryFragment.name2 ??
         '';
   }
 
@@ -98,7 +99,7 @@ class TypeManager with _ImportedTypesMixin {
   Marshaler? getExplicitMarshaler(Element? element) {
     final marshaler =
         // ignore: deprecated_member_use
-        element?.declaration?.getAnnotations().where(_isMarshaler).firstOrNull;
+        element?.getAnnotations().where(_isMarshaler).firstOrNull;
     if (marshaler == null) return null;
     final type = marshaler.toTypeValue() ?? marshaler.type;
     final baseMarshaler = type?.implementedTypes(TSquadronMarshaler);

--- a/lib/src/types/type_manager.dart
+++ b/lib/src/types/type_manager.dart
@@ -38,8 +38,8 @@ class TypeManager with _ImportedTypesMixin {
 
   List<String> checkRequiredImports(List<ImportedType> requiredTypes) {
     final missingImports = requiredTypes.map((t) => t.pckUri).toSet()
-      ..removeWhere((pckUri) =>
-          library.importedLibraries.any((l) => l.isFromPackage(pckUri)));
+      ..removeWhere(
+          (pckUri) => library.allImports.any((l) => l.isFromPackage(pckUri)));
     return missingImports
         .map((s) => s.endsWith('/') ? s.substring(0, s.length - 1) : s)
         .toList();
@@ -50,17 +50,11 @@ class TypeManager with _ImportedTypesMixin {
   String getPrefixFor(Element? element) {
     final lib = switch (element) {
       LibraryElement() => element,
-      // ignore: deprecated_member_use
       Element() => element.library2,
       null => null,
     };
     if (lib == null) return '';
-    // ignore: deprecated_member_use
-    return library.firstFragment.libraryImports2
-            .where((p) => p.importedLibrary2 == lib)
-            .firstOrNull
-            ?.libraryFragment.name2 ??
-        '';
+    return library.getPrefixFor(lib.uri.toString()) ?? '';
   }
 
   final _cache = <DartType, ManagedType>{};

--- a/lib/src/types/type_manager.dart
+++ b/lib/src/types/type_manager.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -14,7 +13,7 @@ class TypeManager with _ImportedTypesMixin {
   TypeManager(this.library)
       : dartCoreAlias = library.getPrefixFor(PckUri.dartCore) ?? '';
 
-  final LibraryElement2 library;
+  final LibraryElement library;
   final String dartCoreAlias;
   late final String squadronAlias;
 

--- a/lib/src/types/type_manager_pck_uri.dart
+++ b/lib/src/types/type_manager_pck_uri.dart
@@ -1,10 +1,10 @@
 part of 'type_manager.dart';
 
 final class PckUri {
-  static const squadron = 'squadron/';
-  static const cancelationToken = 'cancelation_token/';
-  static const using = 'using/';
-  static const logger = 'logger/';
+  static const squadron = 'package:squadron/';
+  static const cancelationToken = 'package:cancelation_token/';
+  static const using = 'package:using/';
+  static const logger = 'package:logger/';
   static const dartCore = 'dart:core';
   static const dartAsync = 'dart:async';
   static const dartTypedData = 'dart:typed_data';

--- a/lib/src/types/type_manager_pck_uri.dart
+++ b/lib/src/types/type_manager_pck_uri.dart
@@ -1,10 +1,10 @@
 part of 'type_manager.dart';
 
 final class PckUri {
-  static const squadron = 'package:squadron/';
-  static const cancelationToken = 'package:cancelation_token/';
-  static const using = 'package:using/';
-  static const logger = 'package:logger/';
+  static const squadron = 'squadron/';
+  static const cancelationToken = 'cancelation_token/';
+  static const using = 'using/';
+  static const logger = 'logger/';
   static const dartCore = 'dart:core';
   static const dartAsync = 'dart:async';
   static const dartTypedData = 'dart:typed_data';

--- a/lib/src/worker_generator.dart
+++ b/lib/src/worker_generator.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:source_gen/source_gen.dart';
@@ -69,13 +70,15 @@ class WorkerGenerator extends GeneratorForAnnotation<squadron.SquadronService> {
 
   @override
   Stream<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async* {
     final classElt = element;
     if (classElt is! ClassElement) return;
-    final libraryName = classElt.librarySource.shortName;
+
+    final libraryName = classElt.library2.name3;
+    if (libraryName == null) return;
 
     final context = _contexts[buildStep];
     if (context == null) {

--- a/lib/src/worker_generator.dart
+++ b/lib/src/worker_generator.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:source_gen/source_gen.dart';
@@ -70,7 +69,7 @@ class WorkerGenerator extends GeneratorForAnnotation<squadron.SquadronService> {
 
   @override
   Stream<String> generateForAnnotatedElement(
-    Element2 element,
+    Element element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async* {

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -1,1 +1,1 @@
-const version = '7.1.4';
+const version = '7.1.5-mki';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: squadron_builder
 description: Dart code generator for Squadron workers. Implement your worker service and let squadron_builder bridge the gap with Web Workers and Isolates!
-version: 7.1.4
+version: 7.1.5-mki
 homepage: https://github.com/d-markey/squadron_builder
 repository: https://github.com/d-markey/squadron_builder
 
@@ -13,10 +13,10 @@ platforms:
   macos:
 
 dependencies:
-  squadron: ^7.1.1
-  build: ^2.4.2
-  source_gen: ^2.0.0
-  analyzer: ^7.1.0
+  squadron: ^7.1.2
+  build: ^3.0.1
+  source_gen: ^3.0.0
+  analyzer: ^7.6.0
   pub_semver:
   meta:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ platforms:
   macos:
 
 dependencies:
-  squadron: ^7.1.2
+  squadron: ^7.1.0
   build: ^3.0.1
   source_gen: ^3.0.0
   analyzer: ^7.6.0


### PR DESCRIPTION
# feat(builder): compatibility with `source_gen` 3.0.0

## Why
Upgrade the code generator to `source_gen` 3.x with no impact on end users.

## Changes
- Migrated to `source_gen >= 3.0.0`
- Minor tweaks for analyzer v2 (import/prefix resolution)
- Internal cleanups and fixes (finalizer)

## Compatibility
- No breaking changes expected in the public API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Worker assets now expose an isStopped getter and a getStats() method.

- Documentation
  - Changelog updated for version 7.1.5-mki noting compatibility updates.

- Refactor
  - Internal migration to newer analyzer APIs to improve generator compatibility without changing existing public behavior.

- Chores
  - Bumped version to 7.1.5-mki.
  - Upgraded dependencies (source_gen 3.x, analyzer 7.6, build 3.x, adjusted squadron constraint) for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->